### PR TITLE
[GitHubEnterprise-3.6] Update to 1.1.4-36c4d728215d3ca0692d176c31bf3a4d from 1.1.4-c825f39066ae2bb949dea996cb2e4b4b

### DIFF
--- a/clients/GitHubEnterprise-3.6/etc/openapi-client-generator.state
+++ b/clients/GitHubEnterprise-3.6/etc/openapi-client-generator.state
@@ -1,5 +1,5 @@
 {
-    "specHash": "c825f39066ae2bb949dea996cb2e4b4b",
+    "specHash": "36c4d728215d3ca0692d176c31bf3a4d",
     "generatedFiles": {
         "files": [
             {
@@ -3188,7 +3188,7 @@
             },
             {
                 "name": ".\/clients\/GitHubEnterprise-3.6\/etc\/..\/\/src\/\/Operation\/EnterpriseAdmin.php",
-                "hash": "4cef97fa75fc8b9ea307c081f9300902"
+                "hash": "3d8a813b8790ad54d2bffd0c66739c8f"
             },
             {
                 "name": ".\/clients\/GitHubEnterprise-3.6\/etc\/..\/\/src\/\/Operation\/Apps.php",
@@ -3244,7 +3244,7 @@
             },
             {
                 "name": ".\/clients\/GitHubEnterprise-3.6\/etc\/..\/\/src\/\/Operation\/Orgs.php",
-                "hash": "5c6ed511574a9b87d1fabaf621a0a6f4"
+                "hash": "d74431dc84f9bb75d786c3d0c5a6a601"
             },
             {
                 "name": ".\/clients\/GitHubEnterprise-3.6\/etc\/..\/\/src\/\/Operation\/CodeScanning.php",
@@ -3268,7 +3268,7 @@
             },
             {
                 "name": ".\/clients\/GitHubEnterprise-3.6\/etc\/..\/\/src\/\/Operation\/Repos.php",
-                "hash": "cfc6103fa8463a2f5f23239412dbf0e3"
+                "hash": "44ffd82bfe6632cdf70b72f2ebfad449"
             },
             {
                 "name": ".\/clients\/GitHubEnterprise-3.6\/etc\/..\/\/src\/\/Operation\/Reactions.php",
@@ -10944,7 +10944,7 @@
             },
             {
                 "name": ".\/clients\/GitHubEnterprise-3.6\/etc\/..\/\/src\/\/Internal\/Operation\/Repos\/CreateDeploymentBranchPolicy.php",
-                "hash": "50b4a56b5a93f60a65abc6c066b36405"
+                "hash": "389af34b5f29f04340176076089f89dd"
             },
             {
                 "name": ".\/clients\/GitHubEnterprise-3.6\/etc\/..\/\/src\/\/Internal\/Operator\/Repos\/CreateDeploymentBranchPolicy.php",
@@ -10952,7 +10952,7 @@
             },
             {
                 "name": ".\/clients\/GitHubEnterprise-3.6\/etc\/..\/\/tests\/\/Internal\/Operation\/Repos\/CreateDeploymentBranchPolicyTest.php",
-                "hash": "cbb4fb7f880b2cbf85c13dcc33bd6810"
+                "hash": "cda0e8cce279d3840bd6eff06f327ecf"
             },
             {
                 "name": ".\/clients\/GitHubEnterprise-3.6\/etc\/..\/\/src\/\/Internal\/Operation\/Repos\/GetDeploymentBranchPolicy.php",
@@ -17989,6 +17989,10 @@
             {
                 "name": ".\/clients\/GitHubEnterprise-3.6\/etc\/..\/\/src\/\/Schema\/AliasAbstract\/TietCDBBBCF8\/TietCDAFCCCF\/Tiet81364F28\/Tiet4334A870.php",
                 "hash": "77d4f1d051525e066a578ff6ac785000"
+            },
+            {
+                "name": ".\/clients\/GitHubEnterprise-3.6\/etc\/..\/\/src\/\/Schema\/DeploymentBranchPolicyNamePatternWithType.php",
+                "hash": "3a11a7271619d6891e96054c5595a690"
             }
         ]
     },

--- a/clients/GitHubEnterprise-3.6/src/Internal/Operation/Repos/CreateDeploymentBranchPolicy.php
+++ b/clients/GitHubEnterprise-3.6/src/Internal/Operation/Repos/CreateDeploymentBranchPolicy.php
@@ -40,7 +40,7 @@ final class CreateDeploymentBranchPolicy
 
     public function createRequest(array $data): RequestInterface
     {
-        $this->requestSchemaValidator->validate($data, Reader::readFromJson(Schema\DeploymentBranchPolicyNamePattern::SCHEMA_JSON, \cebe\openapi\spec\Schema::class));
+        $this->requestSchemaValidator->validate($data, Reader::readFromJson(Schema\DeploymentBranchPolicyNamePatternWithType::SCHEMA_JSON, \cebe\openapi\spec\Schema::class));
 
         return new Request(self::METHOD, str_replace(['{owner}', '{repo}', '{environment_name}'], [$this->owner, $this->repo, $this->environmentName], self::PATH), ['Content-Type' => 'application/json'], json_encode($data));
     }

--- a/clients/GitHubEnterprise-3.6/src/Schema/DeploymentBranchPolicyNamePatternWithType.php
+++ b/clients/GitHubEnterprise-3.6/src/Schema/DeploymentBranchPolicyNamePatternWithType.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ApiClients\Client\GitHubEnterprise\Schema;
+
+final readonly class DeploymentBranchPolicyNamePatternWithType
+{
+    public const SCHEMA_JSON         = '{
+    "title": "Deployment branch policy name pattern",
+    "required": [
+        "name"
+    ],
+    "type": "object",
+    "properties": {
+        "name": {
+            "type": "string",
+            "description": "The name pattern that branches must match in order to deploy to the environment.\\n\\nWildcard characters will not match `\\/`. For example, to match branches that begin with `release\\/` and contain an additional single slash, use `release\\/*\\/*`.\\nFor more information about pattern matching syntax, see the [Ruby File.fnmatch documentation](https:\\/\\/ruby-doc.org\\/core-2.5.1\\/File.html#method-c-fnmatch).",
+            "examples": [
+                "release\\/*"
+            ]
+        }
+    }
+}';
+    public const SCHEMA_TITLE        = 'Deployment branch policy name pattern';
+    public const SCHEMA_DESCRIPTION  = '';
+    public const SCHEMA_EXAMPLE_DATA = '{
+    "name": "release\\/*"
+}';
+
+    /**
+     * name: The name pattern that branches must match in order to deploy to the environment.
+
+    Wildcard characters will not match `/`. For example, to match branches that begin with `release/` and contain an additional single slash, use `release/*`.
+    For more information about pattern matching syntax, see the [Ruby File.fnmatch documentation](https://ruby-doc.org/core-2.5.1/File.html#method-c-fnmatch).
+     */
+    public function __construct(public string $name)
+    {
+    }
+}

--- a/clients/GitHubEnterprise-3.6/tests/Internal/Operation/Repos/CreateDeploymentBranchPolicyTest.php
+++ b/clients/GitHubEnterprise-3.6/tests/Internal/Operation/Repos/CreateDeploymentBranchPolicyTest.php
@@ -29,7 +29,7 @@ final class CreateDeploymentBranchPolicyTest extends AsyncTestCase
         $browser = $this->prophesize(Browser::class);
         $browser->withBase(Argument::any())->willReturn($browser->reveal());
         $browser->withFollowRedirects(Argument::any())->willReturn($browser->reveal());
-        $browser->request('POST', '/repos/generated/generated/environments/generated/deployment-branch-policies', Argument::type('array'), json_encode(json_decode(Schema\DeploymentBranchPolicyNamePattern::SCHEMA_EXAMPLE_DATA, true)))->willReturn(resolve($response))->shouldBeCalled();
+        $browser->request('POST', '/repos/generated/generated/environments/generated/deployment-branch-policies', Argument::type('array'), json_encode(json_decode(Schema\DeploymentBranchPolicyNamePatternWithType::SCHEMA_EXAMPLE_DATA, true)))->willReturn(resolve($response))->shouldBeCalled();
         $client = new Client($auth->reveal(), $browser->reveal());
         $result = $client->call(Internal\Operation\Repos\CreateDeploymentBranchPolicy::OPERATION_MATCH, (static function (array $data): array {
             $data['owner']            = 'generated';
@@ -37,7 +37,7 @@ final class CreateDeploymentBranchPolicyTest extends AsyncTestCase
             $data['environment_name'] = 'generated';
 
             return $data;
-        })(json_decode(Schema\DeploymentBranchPolicyNamePattern::SCHEMA_EXAMPLE_DATA, true)));
+        })(json_decode(Schema\DeploymentBranchPolicyNamePatternWithType::SCHEMA_EXAMPLE_DATA, true)));
     }
 
     /** @test */
@@ -49,9 +49,9 @@ final class CreateDeploymentBranchPolicyTest extends AsyncTestCase
         $browser = $this->prophesize(Browser::class);
         $browser->withBase(Argument::any())->willReturn($browser->reveal());
         $browser->withFollowRedirects(Argument::any())->willReturn($browser->reveal());
-        $browser->request('POST', '/repos/generated/generated/environments/generated/deployment-branch-policies', Argument::type('array'), json_encode(json_decode(Schema\DeploymentBranchPolicyNamePattern::SCHEMA_EXAMPLE_DATA, true)))->willReturn(resolve($response))->shouldBeCalled();
+        $browser->request('POST', '/repos/generated/generated/environments/generated/deployment-branch-policies', Argument::type('array'), json_encode(json_decode(Schema\DeploymentBranchPolicyNamePatternWithType::SCHEMA_EXAMPLE_DATA, true)))->willReturn(resolve($response))->shouldBeCalled();
         $client = new Client($auth->reveal(), $browser->reveal());
-        $result = $client->operations()->repos()->createDeploymentBranchPolicy('generated', 'generated', 'generated', json_decode(Schema\DeploymentBranchPolicyNamePattern::SCHEMA_EXAMPLE_DATA, true));
+        $result = $client->operations()->repos()->createDeploymentBranchPolicy('generated', 'generated', 'generated', json_decode(Schema\DeploymentBranchPolicyNamePatternWithType::SCHEMA_EXAMPLE_DATA, true));
     }
 
     /** @test */
@@ -63,7 +63,7 @@ final class CreateDeploymentBranchPolicyTest extends AsyncTestCase
         $browser = $this->prophesize(Browser::class);
         $browser->withBase(Argument::any())->willReturn($browser->reveal());
         $browser->withFollowRedirects(Argument::any())->willReturn($browser->reveal());
-        $browser->request('POST', '/repos/generated/generated/environments/generated/deployment-branch-policies', Argument::type('array'), json_encode(json_decode(Schema\DeploymentBranchPolicyNamePattern::SCHEMA_EXAMPLE_DATA, true)))->willReturn(resolve($response))->shouldBeCalled();
+        $browser->request('POST', '/repos/generated/generated/environments/generated/deployment-branch-policies', Argument::type('array'), json_encode(json_decode(Schema\DeploymentBranchPolicyNamePatternWithType::SCHEMA_EXAMPLE_DATA, true)))->willReturn(resolve($response))->shouldBeCalled();
         $client = new Client($auth->reveal(), $browser->reveal());
         $result = $client->call(Internal\Operation\Repos\CreateDeploymentBranchPolicy::OPERATION_MATCH, (static function (array $data): array {
             $data['owner']            = 'generated';
@@ -71,7 +71,7 @@ final class CreateDeploymentBranchPolicyTest extends AsyncTestCase
             $data['environment_name'] = 'generated';
 
             return $data;
-        })(json_decode(Schema\DeploymentBranchPolicyNamePattern::SCHEMA_EXAMPLE_DATA, true)));
+        })(json_decode(Schema\DeploymentBranchPolicyNamePatternWithType::SCHEMA_EXAMPLE_DATA, true)));
     }
 
     /** @test */
@@ -83,9 +83,9 @@ final class CreateDeploymentBranchPolicyTest extends AsyncTestCase
         $browser = $this->prophesize(Browser::class);
         $browser->withBase(Argument::any())->willReturn($browser->reveal());
         $browser->withFollowRedirects(Argument::any())->willReturn($browser->reveal());
-        $browser->request('POST', '/repos/generated/generated/environments/generated/deployment-branch-policies', Argument::type('array'), json_encode(json_decode(Schema\DeploymentBranchPolicyNamePattern::SCHEMA_EXAMPLE_DATA, true)))->willReturn(resolve($response))->shouldBeCalled();
+        $browser->request('POST', '/repos/generated/generated/environments/generated/deployment-branch-policies', Argument::type('array'), json_encode(json_decode(Schema\DeploymentBranchPolicyNamePatternWithType::SCHEMA_EXAMPLE_DATA, true)))->willReturn(resolve($response))->shouldBeCalled();
         $client = new Client($auth->reveal(), $browser->reveal());
-        $result = $client->operations()->repos()->createDeploymentBranchPolicy('generated', 'generated', 'generated', json_decode(Schema\DeploymentBranchPolicyNamePattern::SCHEMA_EXAMPLE_DATA, true));
+        $result = $client->operations()->repos()->createDeploymentBranchPolicy('generated', 'generated', 'generated', json_decode(Schema\DeploymentBranchPolicyNamePatternWithType::SCHEMA_EXAMPLE_DATA, true));
         self::assertArrayHasKey('code', $result);
         self::assertSame(404, $result['code']);
     }
@@ -99,7 +99,7 @@ final class CreateDeploymentBranchPolicyTest extends AsyncTestCase
         $browser = $this->prophesize(Browser::class);
         $browser->withBase(Argument::any())->willReturn($browser->reveal());
         $browser->withFollowRedirects(Argument::any())->willReturn($browser->reveal());
-        $browser->request('POST', '/repos/generated/generated/environments/generated/deployment-branch-policies', Argument::type('array'), json_encode(json_decode(Schema\DeploymentBranchPolicyNamePattern::SCHEMA_EXAMPLE_DATA, true)))->willReturn(resolve($response))->shouldBeCalled();
+        $browser->request('POST', '/repos/generated/generated/environments/generated/deployment-branch-policies', Argument::type('array'), json_encode(json_decode(Schema\DeploymentBranchPolicyNamePatternWithType::SCHEMA_EXAMPLE_DATA, true)))->willReturn(resolve($response))->shouldBeCalled();
         $client = new Client($auth->reveal(), $browser->reveal());
         $result = $client->call(Internal\Operation\Repos\CreateDeploymentBranchPolicy::OPERATION_MATCH, (static function (array $data): array {
             $data['owner']            = 'generated';
@@ -107,7 +107,7 @@ final class CreateDeploymentBranchPolicyTest extends AsyncTestCase
             $data['environment_name'] = 'generated';
 
             return $data;
-        })(json_decode(Schema\DeploymentBranchPolicyNamePattern::SCHEMA_EXAMPLE_DATA, true)));
+        })(json_decode(Schema\DeploymentBranchPolicyNamePatternWithType::SCHEMA_EXAMPLE_DATA, true)));
     }
 
     /** @test */
@@ -119,9 +119,9 @@ final class CreateDeploymentBranchPolicyTest extends AsyncTestCase
         $browser = $this->prophesize(Browser::class);
         $browser->withBase(Argument::any())->willReturn($browser->reveal());
         $browser->withFollowRedirects(Argument::any())->willReturn($browser->reveal());
-        $browser->request('POST', '/repos/generated/generated/environments/generated/deployment-branch-policies', Argument::type('array'), json_encode(json_decode(Schema\DeploymentBranchPolicyNamePattern::SCHEMA_EXAMPLE_DATA, true)))->willReturn(resolve($response))->shouldBeCalled();
+        $browser->request('POST', '/repos/generated/generated/environments/generated/deployment-branch-policies', Argument::type('array'), json_encode(json_decode(Schema\DeploymentBranchPolicyNamePatternWithType::SCHEMA_EXAMPLE_DATA, true)))->willReturn(resolve($response))->shouldBeCalled();
         $client = new Client($auth->reveal(), $browser->reveal());
-        $result = $client->operations()->repos()->createDeploymentBranchPolicy('generated', 'generated', 'generated', json_decode(Schema\DeploymentBranchPolicyNamePattern::SCHEMA_EXAMPLE_DATA, true));
+        $result = $client->operations()->repos()->createDeploymentBranchPolicy('generated', 'generated', 'generated', json_decode(Schema\DeploymentBranchPolicyNamePatternWithType::SCHEMA_EXAMPLE_DATA, true));
         self::assertArrayHasKey('code', $result);
         self::assertSame(303, $result['code']);
     }

--- a/etc/specs/GitHubEnterprise-3.6/current.spec.yaml
+++ b/etc/specs/GitHubEnterprise-3.6/current.spec.yaml
@@ -23088,7 +23088,7 @@ paths:
         content:
           application/json:
             schema:
-              "$ref": "#/components/schemas/deployment-branch-policy-name-pattern"
+              "$ref": "#/components/schemas/deployment-branch-policy-name-pattern-with-type"
             examples:
               example-wildcard:
                 summary: Example of a wildcard name pattern
@@ -52439,6 +52439,21 @@ components:
           type: string
           examples:
           - release/*
+    deployment-branch-policy-name-pattern-with-type:
+      title: Deployment branch policy name pattern
+      type: object
+      properties:
+        name:
+          description: |-
+            The name pattern that branches must match in order to deploy to the environment.
+
+            Wildcard characters will not match `/`. For example, to match branches that begin with `release/` and contain an additional single slash, use `release/*/*`.
+            For more information about pattern matching syntax, see the [Ruby File.fnmatch documentation](https://ruby-doc.org/core-2.5.1/File.html#method-c-fnmatch).
+          type: string
+          examples:
+          - release/*
+      required:
+      - name
     deployment-branch-policy-name-pattern:
       title: Deployment branch policy name pattern
       type: object


### PR DESCRIPTION
Detected Schema changes:

├─┬Paths
│ └─┬/repos/{owner}/{repo}/environments/{environment_name}/deployment-branch-policies
│   └─┬POST
│     └─┬Requestbody
│       └─┬application/json
│         └─┬Schema
│           └──[M] $ref (52443:14)❌ 
└─┬Components
  └──[-] schemas (52443:7)❌ 

Date: 09/30/23 | Commit: New: etc/specs/GitHubEnterprise-3.6/previous.spec.yaml, Original: etc/specs/GitHubEnterprise-3.6/current.spec.yaml
Document Element | Total Changes | Breaking Changes
paths            | 1             | 1               
components       | 1             | 1               
❌  2 Breaking changes out of 2
INFO: Modifications: 1
INFO: Removals: 1
INFO: Breaking Removals: 1
INFO: Breaking Modifications: 1

ERROR: breaking changes discovered
