### PR TITLE
[GitHubEnterpriseCloud] Update to 1.1.4-bc4e36d5b31f0f944205ad929c290f0e from 1.1.4-7db4088da848d639855f12c193b9b4b7

### DIFF
--- a/clients/GitHubEnterpriseCloud/etc/openapi-client-generator.state
+++ b/clients/GitHubEnterpriseCloud/etc/openapi-client-generator.state
@@ -1,5 +1,5 @@
 {
-    "specHash": "7db4088da848d639855f12c193b9b4b7",
+    "specHash": "bc4e36d5b31f0f944205ad929c290f0e",
     "generatedFiles": {
         "files": [
             {
@@ -6164,7 +6164,7 @@
             },
             {
                 "name": ".\/clients\/GitHubEnterpriseCloud\/etc\/..\/\/src\/\/Operation\/Codespaces.php",
-                "hash": "eaee03d3778ab08a02421f1dec932d12"
+                "hash": "e9618a09dbd548de21fdcd32adfe8a2c"
             },
             {
                 "name": ".\/clients\/GitHubEnterpriseCloud\/etc\/..\/\/src\/\/Operation\/Packages.php",


### PR DESCRIPTION
Detected Schema changes:
ERROR: error: Error thrown when comparing: local lookups are not permitted, please set AllowFileLookup to true in the configuration


ERROR: local lookups are not permitted, please set AllowFileLookup to true in the configuration
ERROR: component 'server-statistics-actions.yaml' does not exist in the specification
ERROR: local lookups are not permitted, please set AllowFileLookup to true in the configuration
ERROR: component 'server-statistics-packages.yaml' does not exist in the specification
ERROR: cannot resolve reference `server-statistics-actions.yaml`, it's missing:  [217752:11]
ERROR: cannot resolve reference `server-statistics-packages.yaml`, it's missing:  [217754:11]
ERROR: local lookups are not permitted, please set AllowFileLookup to true in the configuration
ERROR: component 'server-statistics-actions.yaml' does not exist in the specification
ERROR: local lookups are not permitted, please set AllowFileLookup to true in the configuration
ERROR: component 'server-statistics-packages.yaml' does not exist in the specification
ERROR: cannot resolve reference `server-statistics-actions.yaml`, it's missing:  [217752:11]
ERROR: cannot resolve reference `server-statistics-packages.yaml`, it's missing:  [217754:11]
