### PR TITLE
[GitHubEnterprise-3.6] Update to 1.1.4-d02643b3a651f9f9678a43fda8691f1c from 1.1.4-62923369a0400f70e7b31c853e54e80c

### DIFF
--- a/clients/GitHubEnterprise-3.6/etc/openapi-client-generator.state
+++ b/clients/GitHubEnterprise-3.6/etc/openapi-client-generator.state
@@ -1,5 +1,5 @@
 {
-    "specHash": "62923369a0400f70e7b31c853e54e80c",
+    "specHash": "d02643b3a651f9f9678a43fda8691f1c",
     "generatedFiles": {
         "files": [
             {

--- a/etc/specs/GitHubEnterprise-3.6/current.spec.yaml
+++ b/etc/specs/GitHubEnterprise-3.6/current.spec.yaml
@@ -68149,7 +68149,7 @@ components:
         node_id: MDEyOldvcmtmbG93IEpvYjM5OTQ0NDQ5Ng==
         head_sha: f83a356604ae3c5d03e1b46ef4d1ca77d64a90b0
         url: https://api.github.com/repos/octo-org/octo-repo/actions/jobs/399444496
-        html_url: https://github.com/octo-org/octo-repo/runs/399444496
+        html_url: https://github.com/octo-org/octo-repo/runs/29679449/jobs/399444496
         status: completed
         conclusion: success
         started_at: '2020-01-20T17:42:40Z'
@@ -68704,7 +68704,7 @@ components:
           node_id: MDEyOldvcmtmbG93IEpvYjM5OTQ0NDQ5Ng==
           head_sha: f83a356604ae3c5d03e1b46ef4d1ca77d64a90b0
           url: https://api.github.com/repos/octo-org/octo-repo/actions/jobs/399444496
-          html_url: https://github.com/octo-org/octo-repo/runs/399444496
+          html_url: https://github.com/octo-org/octo-repo/runs/29679449/jobs/399444496
           status: completed
           conclusion: success
           started_at: '2020-01-20T17:42:40Z'


### PR DESCRIPTION
Detected Schema changes:

└─┬Paths
  ├─┬/repos/{owner}/{repo}/actions/runs/{run_id}/attempts/{attempt_number}/jobs
  │ └─┬GET
  │   └─┬Responses
  │     └─┬200
  │       └─┬application/json
  │         └─┬default
  │           └──[M] value (68699:9)
  ├─┬/repos/{owner}/{repo}/actions/jobs/{job_id}
  │ └─┬GET
  │   └─┬Responses
  │     └─┬200
  │       └─┬application/json
  │         └─┬default
  │           └──[M] value (68146:9)
  └─┬/repos/{owner}/{repo}/actions/runs/{run_id}/jobs
    └─┬GET
      └─┬Responses
        └─┬200
          └─┬application/json
            └─┬default
              └──[M] value (68699:9)

Date: 10/07/23 | Commit: New: etc/specs/GitHubEnterprise-3.6/previous.spec.yaml, Original: etc/specs/GitHubEnterprise-3.6/current.spec.yaml
Document Element | Total Changes | Breaking Changes
paths            | 3             | 0               
INFO: Total Changes: 3
INFO: Modifications: 3
