### PR TITLE
[GitHubEnterpriseCloud] Update to 1.1.4-2b4a22122e4ba3692de6d0a999e3c9e6 from 1.1.4-ced9fc143a93e386ebd99299d1a8adb6

### DIFF
--- a/clients/GitHubEnterpriseCloud/etc/openapi-client-generator.state
+++ b/clients/GitHubEnterpriseCloud/etc/openapi-client-generator.state
@@ -1,5 +1,5 @@
 {
-    "specHash": "ced9fc143a93e386ebd99299d1a8adb6",
+    "specHash": "2b4a22122e4ba3692de6d0a999e3c9e6",
     "generatedFiles": {
         "files": [
             {
@@ -6156,7 +6156,7 @@
             },
             {
                 "name": ".\/clients\/GitHubEnterpriseCloud\/etc\/..\/\/src\/\/Operation\/Orgs.php",
-                "hash": "b80d0808321326e495a44a7ac2e568f1"
+                "hash": "0869714130fb5656360fb06b5f735c91"
             },
             {
                 "name": ".\/clients\/GitHubEnterpriseCloud\/etc\/..\/\/src\/\/Operation\/Oidc.php",
@@ -6188,7 +6188,7 @@
             },
             {
                 "name": ".\/clients\/GitHubEnterpriseCloud\/etc\/..\/\/src\/\/Operation\/Repos.php",
-                "hash": "8f3ab9b231d22f710056c7cd60117ca6"
+                "hash": "eb24ad73b5edd37aaba7cc892b148893"
             },
             {
                 "name": ".\/clients\/GitHubEnterpriseCloud\/etc\/..\/\/src\/\/Operation\/Reactions.php",


### PR DESCRIPTION
Detected Schema changes:
ERROR: error: Error thrown when comparing: open /__w/github-root/github-root/server-statistics-actions.yaml: no such file or directory


ERROR: open /__w/github-root/github-root/server-statistics-actions.yaml: no such file or directory
ERROR: component 'server-statistics-actions.yaml' does not exist in the specification
ERROR: open /__w/github-root/github-root/server-statistics-packages.yaml: no such file or directory
ERROR: component 'server-statistics-packages.yaml' does not exist in the specification
ERROR: cannot resolve reference `server-statistics-actions.yaml`, it's missing:  [218307:11]
ERROR: cannot resolve reference `server-statistics-packages.yaml`, it's missing:  [218309:11]
ERROR: open /__w/github-root/github-root/server-statistics-actions.yaml: no such file or directory
ERROR: component 'server-statistics-actions.yaml' does not exist in the specification
ERROR: open /__w/github-root/github-root/server-statistics-packages.yaml: no such file or directory
ERROR: component 'server-statistics-packages.yaml' does not exist in the specification
ERROR: cannot resolve reference `server-statistics-actions.yaml`, it's missing:  [218326:11]
ERROR: cannot resolve reference `server-statistics-packages.yaml`, it's missing:  [218328:11]
