### PR TITLE
[GitHubEnterprise-3.10] Update to 1.1.4-d06a93798efe69da37d08944b288998b from 1.1.4-3e284339623b593c8f10617b72635c64

### DIFF
--- a/clients/GitHubEnterprise-3.10/etc/openapi-client-generator.state
+++ b/clients/GitHubEnterprise-3.10/etc/openapi-client-generator.state
@@ -1,5 +1,5 @@
 {
-    "specHash": "3e284339623b593c8f10617b72635c64",
+    "specHash": "d06a93798efe69da37d08944b288998b",
     "generatedFiles": {
         "files": [
             {
@@ -13392,7 +13392,7 @@
             },
             {
                 "name": ".\/clients\/GitHubEnterprise-3.10\/etc\/..\/\/src\/\/Operation\/Repos.php",
-                "hash": "2c10f38e1576f838768d4f8969b78629"
+                "hash": "6d7836f7425758e8e451a4e55d3aa69f"
             },
             {
                 "name": ".\/clients\/GitHubEnterprise-3.10\/etc\/..\/\/src\/\/Operation\/Reactions.php",
@@ -29504,7 +29504,7 @@
         "files": [
             {
                 "name": "composer.json",
-                "hash": "5f3d9d2f65a83bddfc6aa39a088a7983"
+                "hash": "423ddf100396993d05459028cf07681e"
             },
             {
                 "name": "composer.lock",


### PR DESCRIPTION
Detected Schema changes:
                                                                                starting work.
                                                                                Building original model for commit 7a28cb
                                                                                
                                                                                └─┬Paths
  └─┬/apps/{app_slug}
    └─┬GET
      └──[M] description (2461:20)

                                                                                SPEC: extracted 2 commits from history
                                                                                Date: 01/29/24 | Commit: New: etc/specs/GitHubEnterprise-3.10/previous.spec.yaml, Original: etc/specs/GitHubEnterprise-3.10/current.spec.yaml
                                                                                DONE: completed

Document Element | Total Changes | Breaking Changes
paths            | 1             | 0

INFO: Total Changes: 1
INFO: Modifications: 1
