### PR TITLE
[GitHubEnterprise-3.11] Update to 1.1.4-a2af7631437bba6d1a0f12872eaf5a11 from 1.1.4-7896308aac5721a0e0d051d14203a71b

### DIFF
--- a/clients/GitHubEnterprise-3.11/etc/openapi-client-generator.state
+++ b/clients/GitHubEnterprise-3.11/etc/openapi-client-generator.state
@@ -1,5 +1,5 @@
 {
-    "specHash": "7896308aac5721a0e0d051d14203a71b",
+    "specHash": "a2af7631437bba6d1a0f12872eaf5a11",
     "generatedFiles": {
         "files": [
             {
@@ -27464,7 +27464,7 @@
             },
             {
                 "name": ".\/clients\/GitHubEnterprise-3.11\/etc\/..\/\/src\/\/Operation\/Repos.php",
-                "hash": "8d20b924a1d9b5f2512dd36b1f93ba12"
+                "hash": "e72ae080de87df83e831060873cb1f3c"
             },
             {
                 "name": ".\/clients\/GitHubEnterprise-3.11\/etc\/..\/\/src\/\/Operation\/Reactions.php",
@@ -30112,7 +30112,7 @@
         "files": [
             {
                 "name": "composer.json",
-                "hash": "765f8ed75a2ecb168d40ad6c546d8dd2"
+                "hash": "2a970068748966a05c58696ac312a68b"
             },
             {
                 "name": "composer.lock",


### PR DESCRIPTION
Detected Schema changes:
                                                                                starting work.
                                                                                Building original model for commit ce3537
                                                                                
                                                                                └─┬Paths
  └─┬/apps/{app_slug}
    └─┬GET
      └──[M] description (2660:20)

                                                                                                                                                                Date: 01/29/24 | Commit: New: etc/specs/GitHubEnterprise-3.11/previous.spec.yaml, Original: etc/specs/GitHubEnterprise-3.11/current.spec.yaml
SPEC: extracted 2 commits from history
                                                                                DONE: completed

Document Element | Total Changes | Breaking Changes
paths            | 1             | 0

INFO: Total Changes: 1
INFO: Modifications: 1
