### PR TITLE
[GitHub] Update to 1.1.4-2bcf4a7ffd1c08c4653f4fa12fbb7e3f from 1.1.4-b854ef7598e090ed26841c01372b8bfc

### DIFF
--- a/clients/GitHub/etc/openapi-client-generator.state
+++ b/clients/GitHub/etc/openapi-client-generator.state
@@ -1,5 +1,5 @@
 {
-    "specHash": "b854ef7598e090ed26841c01372b8bfc",
+    "specHash": "2bcf4a7ffd1c08c4653f4fa12fbb7e3f",
     "generatedFiles": {
         "files": [
             {
@@ -2272,7 +2272,7 @@
             },
             {
                 "name": ".\/clients\/GitHub\/etc\/..\/\/src\/\/Schema\/WebhookPush.php",
-                "hash": "49e13e0ae88b80418a874004500c587f"
+                "hash": "a92e954d794bf3c6b382a2657adb7037"
             },
             {
                 "name": ".\/clients\/GitHub\/etc\/..\/\/src\/\/Schema\/WebhookRegistryPackagePublished.php",
@@ -13532,7 +13532,7 @@
             },
             {
                 "name": ".\/clients\/GitHub\/etc\/..\/\/src\/\/Operation\/Copilot.php",
-                "hash": "e0cc356b1c65d6fecc88aa7e99443b5f"
+                "hash": "290f99dbad083ed35659736cb1c3bf8b"
             },
             {
                 "name": ".\/clients\/GitHub\/etc\/..\/\/src\/\/Schema\/CheckAutomatedSecurityFixes.php",

--- a/clients/GitHub/src/Schema/WebhookPush.php
+++ b/clients/GitHub/src/Schema/WebhookPush.php
@@ -162,7 +162,7 @@ final readonly class WebhookPush
                     }
                 }
             },
-            "description": "An array of commit objects describing the pushed commits. (Pushed commits are all commits that are included in the `compare` between the `before` commit and the `after` commit.) The array includes a maximum of 20 commits. If necessary, you can use the [Commits API](https:\\/\\/docs.github.com\\/rest\\/commits) to fetch additional commits. This limit is applied to timeline events only and isn\'t applied to webhook deliveries."
+            "description": "An array of commit objects describing the pushed commits. (Pushed commits are all commits that are included in the `compare` between the `before` commit and the `after` commit.) The array includes a maximum of 2048 commits. If necessary, you can use the [Commits API](https:\\/\\/docs.github.com\\/rest\\/commits) to fetch additional commits."
         },
         "compare": {
             "type": "string",
@@ -1640,7 +1640,7 @@ final readonly class WebhookPush
     /**
      * after: The SHA of the most recent commit on `ref` after the push.
      * before: The SHA of the most recent commit on `ref` before the push.
-     * commits: An array of commit objects describing the pushed commits. (Pushed commits are all commits that are included in the `compare` between the `before` commit and the `after` commit.) The array includes a maximum of 20 commits. If necessary, you can use the [Commits API](https://docs.github.com/rest/commits) to fetch additional commits. This limit is applied to timeline events only and isn't applied to webhook deliveries.
+     * commits: An array of commit objects describing the pushed commits. (Pushed commits are all commits that are included in the `compare` between the `before` commit and the `after` commit.) The array includes a maximum of 2048 commits. If necessary, you can use the [Commits API](https://docs.github.com/rest/commits) to fetch additional commits.
      * compare: URL that shows the changes in this `ref` update, from the `before` commit to the `after` commit. For a newly created `ref` that is directly based on the default branch, this is the comparison between the head of the default branch and the `after` commit. Otherwise, this shows all commits until the `after` commit.
      * created: Whether this push created the `ref`.
      * deleted: Whether this push deleted the `ref`.


### PR DESCRIPTION
Detected Schema changes:
                                                                                starting work.
                                                                                Building original model for commit 590bd9

                                                                                SPEC: extracted 2 commits from history
├─┬Paths
│ └─┬/repos/{owner}/{repo}/compare/{basehead}
│   └─┬GET
│     └──[M] description (24281:20)
└─┬Components
  └─┬webhook-push
    └─┬commits
      └──[M] description (193765:24)

Date: 02/27/24 | Commit: New: etc/specs/GitHub/previous.spec.yaml, Original: etc/specs/GitHub/current.spec.yaml
Document Element | Total Changes | Breaking Changes
paths            | 1             | 0
components       | 1             | 0

INFO: Total Changes: 2
INFO: Modifications: 2
                                                                                DONE: completed
