### PR TITLE
[GitHubEnterprise-3.10] Update to 1.1.4-93853d65dd4a5c22ecd17ac37aca5790 from 1.1.4-2a6efce13b37ff3271e66169d3196cc2

### DIFF
--- a/clients/GitHubEnterprise-3.10/etc/openapi-client-generator.state
+++ b/clients/GitHubEnterprise-3.10/etc/openapi-client-generator.state
@@ -1,5 +1,5 @@
 {
-    "specHash": "2a6efce13b37ff3271e66169d3196cc2",
+    "specHash": "93853d65dd4a5c22ecd17ac37aca5790",
     "generatedFiles": {
         "files": [
             {
@@ -2328,7 +2328,7 @@
             },
             {
                 "name": ".\/clients\/GitHubEnterprise-3.10\/etc\/..\/\/src\/\/Schema\/WebhookPush.php",
-                "hash": "171e36009f5289b3bc1a8f020c257a2c"
+                "hash": "03aa5b1ee86b34033082f72dfe60e391"
             },
             {
                 "name": ".\/clients\/GitHubEnterprise-3.10\/etc\/..\/\/src\/\/Schema\/WebhookRegistryPackagePublished.php",

--- a/clients/GitHubEnterprise-3.10/src/Schema/WebhookPush.php
+++ b/clients/GitHubEnterprise-3.10/src/Schema/WebhookPush.php
@@ -162,7 +162,7 @@ final readonly class WebhookPush
                     }
                 }
             },
-            "description": "An array of commit objects describing the pushed commits. (Pushed commits are all commits that are included in the `compare` between the `before` commit and the `after` commit.) The array includes a maximum of 20 commits. If necessary, you can use the [Commits API](https:\\/\\/docs.github.com\\/enterprise-server@3.10\\/rest\\/commits) to fetch additional commits. This limit is applied to timeline events only and isn\'t applied to webhook deliveries."
+            "description": "An array of commit objects describing the pushed commits. (Pushed commits are all commits that are included in the `compare` between the `before` commit and the `after` commit.) The array includes a maximum of 2048 commits. If necessary, you can use the [Commits API](https:\\/\\/docs.github.com\\/enterprise-server@3.10\\/rest\\/commits) to fetch additional commits."
         },
         "compare": {
             "type": "string",
@@ -1634,7 +1634,7 @@ final readonly class WebhookPush
     /**
      * after: The SHA of the most recent commit on `ref` after the push.
      * before: The SHA of the most recent commit on `ref` before the push.
-     * commits: An array of commit objects describing the pushed commits. (Pushed commits are all commits that are included in the `compare` between the `before` commit and the `after` commit.) The array includes a maximum of 20 commits. If necessary, you can use the [Commits API](https://docs.github.com/enterprise-server@3.10/rest/commits) to fetch additional commits. This limit is applied to timeline events only and isn't applied to webhook deliveries.
+     * commits: An array of commit objects describing the pushed commits. (Pushed commits are all commits that are included in the `compare` between the `before` commit and the `after` commit.) The array includes a maximum of 2048 commits. If necessary, you can use the [Commits API](https://docs.github.com/enterprise-server@3.10/rest/commits) to fetch additional commits.
      * compare: URL that shows the changes in this `ref` update, from the `before` commit to the `after` commit. For a newly created `ref` that is directly based on the default branch, this is the comparison between the head of the default branch and the `after` commit. Otherwise, this shows all commits until the `after` commit.
      * created: Whether this push created the `ref`.
      * deleted: Whether this push deleted the `ref`.


### PR DESCRIPTION
Detected Schema changes:
                                                                                starting work.
                                                                                Building original model for commit 1166bd

                                                                                SPEC: extracted 2 commits from history
├─┬Paths
│ └─┬/repos/{owner}/{repo}/compare/{basehead}
│   └─┬GET
│     └──[M] description (25166:20)
└─┬Components
  └─┬webhook-push
    └─┬commits
      └──[M] description (184934:24)

Date: 02/28/24 | Commit: New: etc/specs/GitHubEnterprise-3.10/previous.spec.yaml, Original: etc/specs/GitHubEnterprise-3.10/current.spec.yaml
Document Element | Total Changes | Breaking Changes
paths            | 1             | 0
components       | 1             | 0

INFO: Total Changes: 2
INFO: Modifications: 2
                                                                                DONE: completed
