### PR TITLE
[GitHubEnterprise-3.11] Update to 1.1.4-93ee7dda3bc7cff8b5bc6da72e583098 from 1.1.4-89fc2eae57eb967019bd3d981cec95cf

### DIFF
--- a/clients/GitHubEnterprise-3.11/etc/openapi-client-generator.state
+++ b/clients/GitHubEnterprise-3.11/etc/openapi-client-generator.state
@@ -1,5 +1,5 @@
 {
-    "specHash": "89fc2eae57eb967019bd3d981cec95cf",
+    "specHash": "93ee7dda3bc7cff8b5bc6da72e583098",
     "generatedFiles": {
         "files": [
             {
@@ -15260,7 +15260,7 @@
             },
             {
                 "name": ".\/clients\/GitHubEnterprise-3.11\/etc\/..\/\/src\/\/Schema\/WebhookPush.php",
-                "hash": "605cd5532c3dba4bc8c94f214e34e7b3"
+                "hash": "75f7596c2bfdbd1894fe0ef6d16b9412"
             },
             {
                 "name": ".\/clients\/GitHubEnterprise-3.11\/etc\/..\/\/src\/\/Schema\/WebhookRegistryPackagePublished.php",

--- a/clients/GitHubEnterprise-3.11/src/Schema/WebhookPush.php
+++ b/clients/GitHubEnterprise-3.11/src/Schema/WebhookPush.php
@@ -162,7 +162,7 @@ final readonly class WebhookPush
                     }
                 }
             },
-            "description": "An array of commit objects describing the pushed commits. (Pushed commits are all commits that are included in the `compare` between the `before` commit and the `after` commit.) The array includes a maximum of 20 commits. If necessary, you can use the [Commits API](https:\\/\\/docs.github.com\\/enterprise-server@3.11\\/rest\\/commits) to fetch additional commits. This limit is applied to timeline events only and isn\'t applied to webhook deliveries."
+            "description": "An array of commit objects describing the pushed commits. (Pushed commits are all commits that are included in the `compare` between the `before` commit and the `after` commit.) The array includes a maximum of 2048 commits. If necessary, you can use the [Commits API](https:\\/\\/docs.github.com\\/enterprise-server@3.11\\/rest\\/commits) to fetch additional commits."
         },
         "compare": {
             "type": "string",
@@ -1634,7 +1634,7 @@ final readonly class WebhookPush
     /**
      * after: The SHA of the most recent commit on `ref` after the push.
      * before: The SHA of the most recent commit on `ref` before the push.
-     * commits: An array of commit objects describing the pushed commits. (Pushed commits are all commits that are included in the `compare` between the `before` commit and the `after` commit.) The array includes a maximum of 20 commits. If necessary, you can use the [Commits API](https://docs.github.com/enterprise-server@3.11/rest/commits) to fetch additional commits. This limit is applied to timeline events only and isn't applied to webhook deliveries.
+     * commits: An array of commit objects describing the pushed commits. (Pushed commits are all commits that are included in the `compare` between the `before` commit and the `after` commit.) The array includes a maximum of 2048 commits. If necessary, you can use the [Commits API](https://docs.github.com/enterprise-server@3.11/rest/commits) to fetch additional commits.
      * compare: URL that shows the changes in this `ref` update, from the `before` commit to the `after` commit. For a newly created `ref` that is directly based on the default branch, this is the comparison between the head of the default branch and the `after` commit. Otherwise, this shows all commits until the `after` commit.
      * created: Whether this push created the `ref`.
      * deleted: Whether this push deleted the `ref`.


### PR DESCRIPTION
Detected Schema changes:
                                                                                starting work.
                                                                                Building original model for commit c7a317

                                                                                SPEC: extracted 2 commits from history
├─┬Paths
│ └─┬/repos/{owner}/{repo}/compare/{basehead}
│   └─┬GET
│     └──[M] description (25783:20)
└─┬Components
  └─┬webhook-push
    └─┬commits
      └──[M] description (187336:24)

Date: 02/28/24 | Commit: New: etc/specs/GitHubEnterprise-3.11/previous.spec.yaml, Original: etc/specs/GitHubEnterprise-3.11/current.spec.yaml
Document Element | Total Changes | Breaking Changes
paths            | 1             | 0
components       | 1             | 0

INFO: Total Changes: 2
INFO: Modifications: 2
                                                                                DONE: completed
