### PR TITLE
[GitHubEnterprise-3.8] Update to 1.1.4-75cae343d05ec275c00b3c7e009d6cd0 from 1.1.4-6e16f9d48773023a9ee73b54b6afc059

### DIFF
--- a/clients/GitHubEnterprise-3.8/etc/openapi-client-generator.state
+++ b/clients/GitHubEnterprise-3.8/etc/openapi-client-generator.state
@@ -1,5 +1,5 @@
 {
-    "specHash": "6e16f9d48773023a9ee73b54b6afc059",
+    "specHash": "75cae343d05ec275c00b3c7e009d6cd0",
     "generatedFiles": {
         "files": [
             {
@@ -2112,7 +2112,7 @@
             },
             {
                 "name": ".\/clients\/GitHubEnterprise-3.8\/etc\/..\/\/src\/\/Schema\/WebhookPush.php",
-                "hash": "a4bbbf189a4eab2d7f8bd563c629c696"
+                "hash": "6b4145fe4060562395ef2382b9bf932b"
             },
             {
                 "name": ".\/clients\/GitHubEnterprise-3.8\/etc\/..\/\/src\/\/Schema\/WebhookRegistryPackagePublished.php",

--- a/clients/GitHubEnterprise-3.8/src/Schema/WebhookPush.php
+++ b/clients/GitHubEnterprise-3.8/src/Schema/WebhookPush.php
@@ -162,7 +162,7 @@ final readonly class WebhookPush
                     }
                 }
             },
-            "description": "An array of commit objects describing the pushed commits. (Pushed commits are all commits that are included in the `compare` between the `before` commit and the `after` commit.) The array includes a maximum of 20 commits. If necessary, you can use the [Commits API](https:\\/\\/docs.github.com\\/enterprise-server@3.8\\/rest\\/commits) to fetch additional commits. This limit is applied to timeline events only and isn\'t applied to webhook deliveries."
+            "description": "An array of commit objects describing the pushed commits. (Pushed commits are all commits that are included in the `compare` between the `before` commit and the `after` commit.) The array includes a maximum of 2048 commits. If necessary, you can use the [Commits API](https:\\/\\/docs.github.com\\/enterprise-server@3.8\\/rest\\/commits) to fetch additional commits."
         },
         "compare": {
             "type": "string",
@@ -1634,7 +1634,7 @@ final readonly class WebhookPush
     /**
      * after: The SHA of the most recent commit on `ref` after the push.
      * before: The SHA of the most recent commit on `ref` before the push.
-     * commits: An array of commit objects describing the pushed commits. (Pushed commits are all commits that are included in the `compare` between the `before` commit and the `after` commit.) The array includes a maximum of 20 commits. If necessary, you can use the [Commits API](https://docs.github.com/enterprise-server@3.8/rest/commits) to fetch additional commits. This limit is applied to timeline events only and isn't applied to webhook deliveries.
+     * commits: An array of commit objects describing the pushed commits. (Pushed commits are all commits that are included in the `compare` between the `before` commit and the `after` commit.) The array includes a maximum of 2048 commits. If necessary, you can use the [Commits API](https://docs.github.com/enterprise-server@3.8/rest/commits) to fetch additional commits.
      * compare: URL that shows the changes in this `ref` update, from the `before` commit to the `after` commit. For a newly created `ref` that is directly based on the default branch, this is the comparison between the head of the default branch and the `after` commit. Otherwise, this shows all commits until the `after` commit.
      * created: Whether this push created the `ref`.
      * deleted: Whether this push deleted the `ref`.


### PR DESCRIPTION
Detected Schema changes:
                                                                                starting work.
                                                                                Building original model for commit 51e02e

                                                                                SPEC: extracted 2 commits from history
├─┬Paths
│ └─┬/repos/{owner}/{repo}/compare/{basehead}
│   └─┬GET
│     └──[M] description (23309:20)
└─┬Components
  └─┬webhook-push
    └─┬commits
      └──[M] description (179337:24)

Date: 02/28/24 | Commit: New: etc/specs/GitHubEnterprise-3.8/previous.spec.yaml, Original: etc/specs/GitHubEnterprise-3.8/current.spec.yaml
Document Element | Total Changes | Breaking Changes
paths            | 1             | 0
components       | 1             | 0

INFO: Total Changes: 2
INFO: Modifications: 2
                                                                                DONE: completed
