### PR TITLE
[GitHubEnterprise-3.9] Update to 1.1.4-3d7efd00cd91e95f942be168f47f2951 from 1.1.4-3c3d71cb8f98e214cff5331c1497c0be

### DIFF
--- a/clients/GitHubEnterprise-3.9/etc/openapi-client-generator.state
+++ b/clients/GitHubEnterprise-3.9/etc/openapi-client-generator.state
@@ -1,5 +1,5 @@
 {
-    "specHash": "3c3d71cb8f98e214cff5331c1497c0be",
+    "specHash": "3d7efd00cd91e95f942be168f47f2951",
     "generatedFiles": {
         "files": [
             {
@@ -2188,7 +2188,7 @@
             },
             {
                 "name": ".\/clients\/GitHubEnterprise-3.9\/etc\/..\/\/src\/\/Schema\/WebhookPush.php",
-                "hash": "e98932bf92b41aa77707c8eb9706abf2"
+                "hash": "6dec90f4d294b344b327d9d686371683"
             },
             {
                 "name": ".\/clients\/GitHubEnterprise-3.9\/etc\/..\/\/src\/\/Schema\/WebhookRegistryPackagePublished.php",

--- a/clients/GitHubEnterprise-3.9/src/Schema/WebhookPush.php
+++ b/clients/GitHubEnterprise-3.9/src/Schema/WebhookPush.php
@@ -162,7 +162,7 @@ final readonly class WebhookPush
                     }
                 }
             },
-            "description": "An array of commit objects describing the pushed commits. (Pushed commits are all commits that are included in the `compare` between the `before` commit and the `after` commit.) The array includes a maximum of 20 commits. If necessary, you can use the [Commits API](https:\\/\\/docs.github.com\\/enterprise-server@3.9\\/rest\\/commits) to fetch additional commits. This limit is applied to timeline events only and isn\'t applied to webhook deliveries."
+            "description": "An array of commit objects describing the pushed commits. (Pushed commits are all commits that are included in the `compare` between the `before` commit and the `after` commit.) The array includes a maximum of 2048 commits. If necessary, you can use the [Commits API](https:\\/\\/docs.github.com\\/enterprise-server@3.9\\/rest\\/commits) to fetch additional commits."
         },
         "compare": {
             "type": "string",
@@ -1634,7 +1634,7 @@ final readonly class WebhookPush
     /**
      * after: The SHA of the most recent commit on `ref` after the push.
      * before: The SHA of the most recent commit on `ref` before the push.
-     * commits: An array of commit objects describing the pushed commits. (Pushed commits are all commits that are included in the `compare` between the `before` commit and the `after` commit.) The array includes a maximum of 20 commits. If necessary, you can use the [Commits API](https://docs.github.com/enterprise-server@3.9/rest/commits) to fetch additional commits. This limit is applied to timeline events only and isn't applied to webhook deliveries.
+     * commits: An array of commit objects describing the pushed commits. (Pushed commits are all commits that are included in the `compare` between the `before` commit and the `after` commit.) The array includes a maximum of 2048 commits. If necessary, you can use the [Commits API](https://docs.github.com/enterprise-server@3.9/rest/commits) to fetch additional commits.
      * compare: URL that shows the changes in this `ref` update, from the `before` commit to the `after` commit. For a newly created `ref` that is directly based on the default branch, this is the comparison between the head of the default branch and the `after` commit. Otherwise, this shows all commits until the `after` commit.
      * created: Whether this push created the `ref`.
      * deleted: Whether this push deleted the `ref`.


### PR DESCRIPTION
Detected Schema changes:
                                                                                starting work.
                                                                                Building original model for commit ce28ce

                                                                                SPEC: extracted 2 commits from history
├─┬Paths
│ └─┬/repos/{owner}/{repo}/compare/{basehead}
│   └─┬GET
│     └──[M] description (24273:20)
└─┬Components
  └─┬webhook-push
    └─┬commits
      └──[M] description (182759:24)

Date: 02/28/24 | Commit: New: etc/specs/GitHubEnterprise-3.9/previous.spec.yaml, Original: etc/specs/GitHubEnterprise-3.9/current.spec.yaml
Document Element | Total Changes | Breaking Changes
paths            | 1             | 0
components       | 1             | 0

INFO: Total Changes: 2
INFO: Modifications: 2
                                                                                DONE: completed
