### PR TITLE
[GitHubEnterpriseCloud] Update to 1.1.4-20a4c85d79ff80bf088ddc35f1f2c3e7 from 1.1.4-85efe1c3a31046a555d291a7d871e343

### DIFF
--- a/clients/GitHubEnterpriseCloud/etc/openapi-client-generator.state
+++ b/clients/GitHubEnterpriseCloud/etc/openapi-client-generator.state
@@ -1,5 +1,5 @@
 {
-    "specHash": "85efe1c3a31046a555d291a7d871e343",
+    "specHash": "20a4c85d79ff80bf088ddc35f1f2c3e7",
     "generatedFiles": {
         "files": [
             {
@@ -6168,7 +6168,7 @@
             },
             {
                 "name": ".\/clients\/GitHubEnterpriseCloud\/etc\/..\/\/src\/\/Operation\/Repos.php",
-                "hash": "9f83d7bad2b42b8ed0eadb30ffe07b73"
+                "hash": "70b8434c4d0615054eb9c4956fce9428"
             },
             {
                 "name": ".\/clients\/GitHubEnterpriseCloud\/etc\/..\/\/src\/\/Operation\/Reactions.php",


### PR DESCRIPTION
Detected Schema changes:
                                                                                starting work.
                                                                                Building original model for commit 1b5a95
2024-03-22 17:23:27 ERROR unable to open the rolodex file, check specification references and base path
                      ├ file: /__w/github-root/github-root/server-statistics-actions.yaml
                      └ error: open /__w/github-root/github-root/server-statistics-actions.yaml: no such file or directory
2024-03-22 17:23:27 ERROR unable to open the rolodex file, check specification references and base path
                      ├ file: /__w/github-root/github-root/server-statistics-packages.yaml
                      └ error: open /__w/github-root/github-root/server-statistics-packages.yaml: no such file or directory
2024-03-22 17:23:30 ERROR unable to open the rolodex file, check specification references and base path
                      ├ file: /__w/github-root/github-root/server-statistics-actions.yaml
                      └ error: open /__w/github-root/github-root/server-statistics-actions.yaml: no such file or directory
2024-03-22 17:23:30 ERROR unable to open the rolodex file, check specification references and base path
                      ├ file: /__w/github-root/github-root/server-statistics-packages.yaml
                      └ error: open /__w/github-root/github-root/server-statistics-packages.yaml: no such file or directory
                                                                                SPEC: extracted 1 commits from history

                                                                                DONE: completed
WARNING: warnings reported during processing
⚠️  Error thrown when comparing: component 'server-statistics-actions.yaml' does not exist in the specification
