### PR TITLE
[GitHubEnterpriseCloud] Update to 1.1.4-d61670a493c4eff3a04ce0deec100fb7 from 1.1.4-041810bc991810fa97b34eae71cba9ac

### DIFF
--- a/clients/GitHubEnterpriseCloud/etc/openapi-client-generator.state
+++ b/clients/GitHubEnterpriseCloud/etc/openapi-client-generator.state
@@ -1,5 +1,5 @@
 {
-    "specHash": "041810bc991810fa97b34eae71cba9ac",
+    "specHash": "d61670a493c4eff3a04ce0deec100fb7",
     "generatedFiles": {
         "files": [
             {
@@ -6008,7 +6008,7 @@
             },
             {
                 "name": ".\/clients\/GitHubEnterpriseCloud\/etc\/..\/\/src\/\/Operation\/Pulls.php",
-                "hash": "de2c25c9cb75e3ac17a7889ad5296a73"
+                "hash": "e28481d1ae839ea433eae30e279e3692"
             },
             {
                 "name": ".\/clients\/GitHubEnterpriseCloud\/etc\/..\/\/src\/\/Operation\/SecurityAdvisories.php",


### PR DESCRIPTION
Detected Schema changes:
                                                                                starting work.
                                                                                Building original model for commit a1f38b
2024-05-29 00:21:27 ERROR unable to open the rolodex file, check specification references and base path
                      ├ file: /__w/github-root/github-root/server-statistics-actions.yaml
                      └ error: open /__w/github-root/github-root/server-statistics-actions.yaml: no such file or directory
2024-05-29 00:21:27 ERROR unable to open the rolodex file, check specification references and base path
                      ├ file: /__w/github-root/github-root/server-statistics-packages.yaml
                      └ error: open /__w/github-root/github-root/server-statistics-packages.yaml: no such file or directory
2024-05-29 00:21:30 ERROR unable to open the rolodex file, check specification references and base path
                      ├ file: /__w/github-root/github-root/server-statistics-packages.yaml
                      └ error: open /__w/github-root/github-root/server-statistics-packages.yaml: no such file or directory
2024-05-29 00:21:30 ERROR unable to open the rolodex file, check specification references and base path
                      ├ file: /__w/github-root/github-root/server-statistics-actions.yaml
                      └ error: open /__w/github-root/github-root/server-statistics-actions.yaml: no such file or directory
                                                                                ERROR: component 'server-statistics-actions.yaml' does not exist in the specification
                                                                                ERROR: component 'server-statistics-packages.yaml' does not exist in the specification
                                                                                ERROR: cannot resolve reference `server-statistics-actions.yaml`, it's missing:  [203315:11]
                                                                                ERROR: cannot resolve reference `server-statistics-packages.yaml`, it's missing:  [203317:11]
                                                                                ERROR: component 'server-statistics-packages.yaml' does not exist in the specification
                                                                                ERROR: component 'server-statistics-actions.yaml' does not exist in the specification
                                                                                ERROR: cannot resolve reference `server-statistics-actions.yaml`, it's missing:  [203315:11]
                                                                                ERROR: cannot resolve reference `server-statistics-packages.yaml`, it's missing:  [203317:11]
