### PR TITLE
[GitHubEnterpriseCloud] Update to 1.1.4-161166e01fd79918e39c52792abbb175 from 1.1.4-161166e01fd79918e39c52792abbb175

### DIFF
--- a/clients/GitHubEnterpriseCloud/etc/openapi-client-generator.state
+++ b/clients/GitHubEnterpriseCloud/etc/openapi-client-generator.state
@@ -5924,11 +5924,11 @@
             },
             {
                 "name": ".\/clients\/GitHubEnterpriseCloud\/etc\/..\/\/src\/\/Operation\/Billing.php",
-                "hash": "5e4c14373b71a269b089cdeccad67f3b"
+                "hash": "966f7db10e65ae9cd5ee44b95c168b21"
             },
             {
                 "name": ".\/clients\/GitHubEnterpriseCloud\/etc\/..\/\/src\/\/Operation\/Activity.php",
-                "hash": "3a701c2ab7dcc6c1e3adda52ac937bcc"
+                "hash": "52e2d03bf9824b479a8702cf7bb88e27"
             },
             {
                 "name": ".\/clients\/GitHubEnterpriseCloud\/etc\/..\/\/src\/\/Operation\/Gists.php",
@@ -31992,7 +31992,7 @@
             },
             {
                 "name": "..\/..\/composer.lock",
-                "hash": "896c1363277f60ac64a6288682a2713a"
+                "hash": "87ff545c771fcddd769df42fa210ed40"
             }
         ]
     }


### PR DESCRIPTION
Detected Schema changes:
                                                                                starting work.
                                                                                Building original model for commit 8a42ae
2024-06-06 11:25:33 ERROR unable to open the rolodex file, check specification references and base path
                      ├ file: /__w/github-root/github-root/server-statistics-actions.yaml
                      └ error: open /__w/github-root/github-root/server-statistics-actions.yaml: no such file or directory
2024-06-06 11:25:33 ERROR unable to open the rolodex file, check specification references and base path
                      ├ file: /__w/github-root/github-root/server-statistics-packages.yaml
                      └ error: open /__w/github-root/github-root/server-statistics-packages.yaml: no such file or directory
2024-06-06 11:25:36 ERROR unable to open the rolodex file, check specification references and base path
                      ├ file: /__w/github-root/github-root/server-statistics-actions.yaml
                      └ error: open /__w/github-root/github-root/server-statistics-actions.yaml: no such file or directory
2024-06-06 11:25:36 ERROR unable to open the rolodex file, check specification references and base path
                      ├ file: /__w/github-root/github-root/server-statistics-packages.yaml
                      └ error: open /__w/github-root/github-root/server-statistics-packages.yaml: no such file or directory
                                                                                ERROR: component 'server-statistics-actions.yaml' does not exist in the specification
                                                                                ERROR: component 'server-statistics-packages.yaml' does not exist in the specification
                                                                                ERROR: cannot resolve reference `server-statistics-actions.yaml`, it's missing:  [203597:11]
                                                                                ERROR: cannot resolve reference `server-statistics-packages.yaml`, it's missing:  [203599:11]
                                                                                ERROR: component 'server-statistics-actions.yaml' does not exist in the specification
                                                                                ERROR: component 'server-statistics-packages.yaml' does not exist in the specification
                                                                                ERROR: cannot resolve reference `server-statistics-actions.yaml`, it's missing:  [203597:11]
                                                                                ERROR: cannot resolve reference `server-statistics-packages.yaml`, it's missing:  [203599:11]
