### PR TITLE
[GitHubEnterpriseCloud] Update to 1.1.4-b27c55fe8bd2fdd9a35c169d7fc9ddf7 from 1.1.4-5ebfc5c2a69a8e68eadbe18dfa04e5f0

### DIFF
--- a/clients/GitHubEnterpriseCloud/etc/openapi-client-generator.state
+++ b/clients/GitHubEnterpriseCloud/etc/openapi-client-generator.state
@@ -1,5 +1,5 @@
 {
-    "specHash": "5ebfc5c2a69a8e68eadbe18dfa04e5f0",
+    "specHash": "b27c55fe8bd2fdd9a35c169d7fc9ddf7",
     "generatedFiles": {
         "files": [
             {
@@ -308,7 +308,7 @@
             },
             {
                 "name": ".\/clients\/GitHubEnterpriseCloud\/etc\/..\/\/src\/\/Schema\/CodeScanningOrganizationAlertItems.php",
-                "hash": "0608eacaed858dc89ae368785590e06c"
+                "hash": "a6c528927db9a2f80f2c3abef839d742"
             },
             {
                 "name": ".\/clients\/GitHubEnterpriseCloud\/etc\/..\/\/src\/\/Schema\/EnterpriseSecurityAnalysisSettings.php",
@@ -948,11 +948,11 @@
             },
             {
                 "name": ".\/clients\/GitHubEnterpriseCloud\/etc\/..\/\/src\/\/Schema\/CodeScanningAlertRuleSummary.php",
-                "hash": "9f9e0ecb5585fc172d0c0202843cd1cf"
+                "hash": "7eb5db688e3e77c8ff28b8795fdee346"
             },
             {
                 "name": ".\/clients\/GitHubEnterpriseCloud\/etc\/..\/\/src\/\/Schema\/CodeScanningAlertItems.php",
-                "hash": "be10971a0cba9644e38d8635d5962da9"
+                "hash": "1f104b153a76541dfec1986d268150cb"
             },
             {
                 "name": ".\/clients\/GitHubEnterpriseCloud\/etc\/..\/\/src\/\/Schema\/CodeScanningAlert.php",
@@ -1412,7 +1412,7 @@
             },
             {
                 "name": ".\/clients\/GitHubEnterpriseCloud\/etc\/..\/\/src\/\/Schema\/PullRequestReview.php",
-                "hash": "6c07acc5f100e7509e6bbee385c255b8"
+                "hash": "a60aa17f28ab6a8d57ff8cbac64260dd"
             },
             {
                 "name": ".\/clients\/GitHubEnterpriseCloud\/etc\/..\/\/src\/\/Schema\/ReviewComment.php",
@@ -5980,7 +5980,7 @@
             },
             {
                 "name": ".\/clients\/GitHubEnterpriseCloud\/etc\/..\/\/src\/\/Operation\/Repos.php",
-                "hash": "4f5d7fef37bd2120a1780f62f55955d4"
+                "hash": "ee379c7bf3e8c92f7c9bd9cf18e84d63"
             },
             {
                 "name": ".\/clients\/GitHubEnterpriseCloud\/etc\/..\/\/src\/\/Operation\/Reactions.php",
@@ -32160,7 +32160,7 @@
             },
             {
                 "name": ".\/clients\/GitHubEnterpriseCloud\/etc\/..\/\/src\/\/Operation\/CodeSecurity.php",
-                "hash": "fde1258be104d6d06536f578b6fa8c18"
+                "hash": "604ee98b68512191da9e8d433c401be0"
             },
             {
                 "name": ".\/clients\/GitHubEnterpriseCloud\/etc\/..\/\/src\/\/Internal\/Hydrator\/Operation\/Orgs\/Org\/CodeSecurity\/Configurations.php",

--- a/clients/GitHubEnterpriseCloud/src/Schema/CodeScanningAlertItems.php
+++ b/clients/GitHubEnterpriseCloud/src/Schema/CodeScanningAlertItems.php
@@ -292,16 +292,6 @@ final readonly class CodeScanningAlertItems
                     "type": "string",
                     "description": "The name of the rule used to detect the alert."
                 },
-                "tags": {
-                    "type": [
-                        "array",
-                        "null"
-                    ],
-                    "items": {
-                        "type": "string"
-                    },
-                    "description": "A set of tags applicable for the rule."
-                },
                 "severity": {
                     "enum": [
                         "none",
@@ -333,6 +323,16 @@ final readonly class CodeScanningAlertItems
                 "description": {
                     "type": "string",
                     "description": "A short description of the rule used to detect the alert."
+                },
+                "tags": {
+                    "type": [
+                        "array",
+                        "null"
+                    ],
+                    "items": {
+                        "type": "string"
+                    },
+                    "description": "A set of tags applicable for the rule."
                 }
             }
         },
@@ -484,10 +484,10 @@ final readonly class CodeScanningAlertItems
     "rule": {
         "id": "generated",
         "name": "generated",
-        "tags": null,
         "severity": "error",
         "security_severity_level": "low",
-        "description": "generated"
+        "description": "generated",
+        "tags": null
     },
     "tool": {
         "name": "generated",

--- a/clients/GitHubEnterpriseCloud/src/Schema/CodeScanningAlertRuleSummary.php
+++ b/clients/GitHubEnterpriseCloud/src/Schema/CodeScanningAlertRuleSummary.php
@@ -22,16 +22,6 @@ final readonly class CodeScanningAlertRuleSummary
             "type": "string",
             "description": "The name of the rule used to detect the alert."
         },
-        "tags": {
-            "type": [
-                "array",
-                "null"
-            ],
-            "items": {
-                "type": "string"
-            },
-            "description": "A set of tags applicable for the rule."
-        },
         "severity": {
             "enum": [
                 "none",
@@ -63,6 +53,16 @@ final readonly class CodeScanningAlertRuleSummary
         "description": {
             "type": "string",
             "description": "A short description of the rule used to detect the alert."
+        },
+        "tags": {
+            "type": [
+                "array",
+                "null"
+            ],
+            "items": {
+                "type": "string"
+            },
+            "description": "A set of tags applicable for the rule."
         }
     }
 }';
@@ -71,22 +71,22 @@ final readonly class CodeScanningAlertRuleSummary
     public const SCHEMA_EXAMPLE_DATA = '{
     "id": "generated",
     "name": "generated",
-    "tags": null,
     "severity": "error",
     "security_severity_level": "low",
-    "description": "generated"
+    "description": "generated",
+    "tags": null
 }';
 
     /**
      * id: A unique identifier for the rule used to detect the alert.
      * name: The name of the rule used to detect the alert.
-     * tags: A set of tags applicable for the rule.
      * severity: The severity of the alert.
      * securitySeverityLevel: The security severity of the alert.
      * description: A short description of the rule used to detect the alert.
+     * tags: A set of tags applicable for the rule.
      */
-    public function __construct(public string|null $id, public string|null $name, public array|null $tags, public string|null $severity, #[MapFrom('security_severity_level')]
-    public string|null $securitySeverityLevel, public string|null $description,)
+    public function __construct(public string|null $id, public string|null $name, public string|null $severity, #[MapFrom('security_severity_level')]
+    public string|null $securitySeverityLevel, public string|null $description, public array|null $tags,)
     {
     }
 }

--- a/clients/GitHubEnterpriseCloud/src/Schema/CodeScanningOrganizationAlertItems.php
+++ b/clients/GitHubEnterpriseCloud/src/Schema/CodeScanningOrganizationAlertItems.php
@@ -293,16 +293,6 @@ final readonly class CodeScanningOrganizationAlertItems
                     "type": "string",
                     "description": "The name of the rule used to detect the alert."
                 },
-                "tags": {
-                    "type": [
-                        "array",
-                        "null"
-                    ],
-                    "items": {
-                        "type": "string"
-                    },
-                    "description": "A set of tags applicable for the rule."
-                },
                 "severity": {
                     "enum": [
                         "none",
@@ -334,6 +324,16 @@ final readonly class CodeScanningOrganizationAlertItems
                 "description": {
                     "type": "string",
                     "description": "A short description of the rule used to detect the alert."
+                },
+                "tags": {
+                    "type": [
+                        "array",
+                        "null"
+                    ],
+                    "items": {
+                        "type": "string"
+                    },
+                    "description": "A set of tags applicable for the rule."
                 }
             }
         },
@@ -1030,10 +1030,10 @@ final readonly class CodeScanningOrganizationAlertItems
     "rule": {
         "id": "generated",
         "name": "generated",
-        "tags": null,
         "severity": "error",
         "security_severity_level": "low",
-        "description": "generated"
+        "description": "generated",
+        "tags": null
     },
     "tool": {
         "name": "generated",

--- a/clients/GitHubEnterpriseCloud/src/Schema/PullRequestReview.php
+++ b/clients/GitHubEnterpriseCloud/src/Schema/PullRequestReview.php
@@ -28,6 +28,7 @@ final readonly class PullRequestReview
         "id": {
             "type": "integer",
             "description": "Unique identifier of the review",
+            "format": "int64",
             "examples": [
                 42
             ]


### PR DESCRIPTION
Detected Schema changes:
2024-08-02 17:26:21 ERROR unable to open the rolodex file, check specification references and base path
                      ├ file: /__w/github-root/github-root/server-statistics-actions.yaml
                      └ error: open /__w/github-root/github-root/server-statistics-actions.yaml: no such file or directory
2024-08-02 17:26:21 ERROR unable to open the rolodex file, check specification references and base path
                      ├ file: /__w/github-root/github-root/server-statistics-packages.yaml
                      └ error: open /__w/github-root/github-root/server-statistics-packages.yaml: no such file or directory
2024-08-02 17:26:21 ERROR unable to open the rolodex file, check specification references and base path
                      ├ file: /__w/github-root/github-root/server-statistics-advisory-db.yaml
                      └ error: open /__w/github-root/github-root/server-statistics-advisory-db.yaml: no such file or directory
2024-08-02 17:26:24 ERROR unable to open the rolodex file, check specification references and base path
                      ├ file: /__w/github-root/github-root/server-statistics-actions.yaml
                      └ error: open /__w/github-root/github-root/server-statistics-actions.yaml: no such file or directory
2024-08-02 17:26:24 ERROR unable to open the rolodex file, check specification references and base path
                      ├ file: /__w/github-root/github-root/server-statistics-packages.yaml
                      └ error: open /__w/github-root/github-root/server-statistics-packages.yaml: no such file or directory
2024-08-02 17:26:24 ERROR unable to open the rolodex file, check specification references and base path
                      ├ file: /__w/github-root/github-root/server-statistics-advisory-db.yaml
                      └ error: open /__w/github-root/github-root/server-statistics-advisory-db.yaml: no such file or directory
ERROR: component 'server-statistics-actions.yaml' does not exist in the specification
ERROR: component 'server-statistics-packages.yaml' does not exist in the specification
ERROR: component 'server-statistics-advisory-db.yaml' does not exist in the specification
ERROR: cannot resolve reference `server-statistics-actions.yaml`, it's missing:  [207106:11]
ERROR: cannot resolve reference `server-statistics-packages.yaml`, it's missing:  [207108:11]
ERROR: cannot resolve reference `server-statistics-advisory-db.yaml`, it's missing:  [207110:11]
ERROR: component 'server-statistics-actions.yaml' does not exist in the specification
ERROR: component 'server-statistics-packages.yaml' does not exist in the specification
ERROR: component 'server-statistics-advisory-db.yaml' does not exist in the specification
ERROR: cannot resolve reference `server-statistics-actions.yaml`, it's missing:  [207088:11]
ERROR: cannot resolve reference `server-statistics-packages.yaml`, it's missing:  [207090:11]
ERROR: cannot resolve reference `server-statistics-advisory-db.yaml`, it's missing:  [207092:11]
