### PR TITLE
[GitHub] Update to 1.1.4-fab1ddd37553337c5ed4418939293ccb from 1.1.4-12cb03fcf4474304824f71a72f6d6238

### DIFF
--- a/clients/GitHub/etc/openapi-client-generator.state
+++ b/clients/GitHub/etc/openapi-client-generator.state
@@ -1,5 +1,5 @@
 {
-    "specHash": "12cb03fcf4474304824f71a72f6d6238",
+    "specHash": "fab1ddd37553337c5ed4418939293ccb",
     "generatedFiles": {
         "files": [
             {
@@ -600,11 +600,11 @@
             },
             {
                 "name": ".\/clients\/GitHub\/etc\/..\/\/src\/\/Schema\/RepositoryRule.php",
-                "hash": "0cde54936a5777cf5f9fd605e1049036"
+                "hash": "27db5ee40bc66c7b5f0beb5b27918e39"
             },
             {
                 "name": ".\/clients\/GitHub\/etc\/..\/\/src\/\/Schema\/RepositoryRuleset.php",
-                "hash": "8e1c29ff35771f7f17d22547af662cd5"
+                "hash": "8e6765e2f48edf50f04ce11713e70199"
             },
             {
                 "name": ".\/clients\/GitHub\/etc\/..\/\/src\/\/Schema\/ActionsBillingUsage.php",
@@ -4628,11 +4628,11 @@
             },
             {
                 "name": ".\/clients\/GitHub\/etc\/..\/\/src\/\/Schema\/Repos\/CreateOrgRuleset\/Request\/ApplicationJson.php",
-                "hash": "524ca93d133aca32bba1b90d3bbed201"
+                "hash": "891ec985ac5c4ba1100b03cd76a706c4"
             },
             {
                 "name": ".\/clients\/GitHub\/etc\/..\/\/src\/\/Schema\/Repos\/UpdateOrgRuleset\/Request\/ApplicationJson.php",
-                "hash": "867f2d550a888bc7d8b48c12f4ba6791"
+                "hash": "9f59f5288c1769e0b9c886709ef76d39"
             },
             {
                 "name": ".\/clients\/GitHub\/etc\/..\/\/src\/\/Schema\/Teams\/Create\/Request\/ApplicationJson.php",
@@ -5336,11 +5336,11 @@
             },
             {
                 "name": ".\/clients\/GitHub\/etc\/..\/\/src\/\/Schema\/Repos\/CreateRepoRuleset\/Request\/ApplicationJson.php",
-                "hash": "272bb8ffe70c702cdc4530b7c27143a9"
+                "hash": "a0eccc012be49d7c97b15e0db850367f"
             },
             {
                 "name": ".\/clients\/GitHub\/etc\/..\/\/src\/\/Schema\/Repos\/UpdateRepoRuleset\/Request\/ApplicationJson.php",
-                "hash": "672be99a3aa2ca2ed1bb907a94e80996"
+                "hash": "4aba68f175748394b8f1a650c5953166"
             },
             {
                 "name": ".\/clients\/GitHub\/etc\/..\/\/src\/\/Schema\/SecretScanning\/UpdateAlert\/Request\/ApplicationJson.php",
@@ -11800,15 +11800,15 @@
             },
             {
                 "name": ".\/clients\/GitHub\/etc\/..\/\/src\/\/Schema\/WebhookRepositoryRulesetCreated.php",
-                "hash": "1e67457d601830a99b9df3f28ba56dff"
+                "hash": "81833c1765d22bd9b0a84552a11eebdb"
             },
             {
                 "name": ".\/clients\/GitHub\/etc\/..\/\/src\/\/Schema\/WebhookRepositoryRulesetDeleted.php",
-                "hash": "fd7a4a3b361d64cc6351572d60d5d500"
+                "hash": "660ebab2bd94bd9463ef010ad0c3819f"
             },
             {
                 "name": ".\/clients\/GitHub\/etc\/..\/\/src\/\/Schema\/WebhookRepositoryRulesetEdited.php",
-                "hash": "ce991a6d07a851f3e27ef12ce1041c11"
+                "hash": "a12764fb2a57245294049c90867e9d9b"
             },
             {
                 "name": ".\/clients\/GitHub\/etc\/..\/\/src\/\/Schema\/WebhookDeploymentReviewApproved\/WorkflowRun\/Actor.php",
@@ -12044,7 +12044,7 @@
             },
             {
                 "name": ".\/clients\/GitHub\/etc\/..\/\/src\/\/Schema\/WebhookRepositoryRulesetEdited\/Changes.php",
-                "hash": "69570983633b85b4dddf93bd65f1da54"
+                "hash": "189095656fdb3ccad9913848a3fcfc53"
             },
             {
                 "name": ".\/clients\/GitHub\/etc\/..\/\/src\/\/Schema\/WebhookRepositoryRulesetEdited\/Changes\/Conditions.php",
@@ -12072,11 +12072,11 @@
             },
             {
                 "name": ".\/clients\/GitHub\/etc\/..\/\/src\/\/Schema\/WebhookRepositoryRulesetEdited\/Changes\/Rules.php",
-                "hash": "0c316e592a986cc658b4d87b4ecc52bf"
+                "hash": "f4761308db669132281332d3f4b8cc87"
             },
             {
                 "name": ".\/clients\/GitHub\/etc\/..\/\/src\/\/Schema\/WebhookRepositoryRulesetEdited\/Changes\/Rules\/Updated.php",
-                "hash": "4803aa143658201cd085fc623d69ffb0"
+                "hash": "f4e1ad02080f231e08a48f1b9296e951"
             },
             {
                 "name": ".\/clients\/GitHub\/etc\/..\/\/src\/\/Schema\/WebhookRepositoryRulesetEdited\/Changes\/Rules\/Updated\/Changes.php",
@@ -29180,7 +29180,7 @@
             },
             {
                 "name": ".\/clients\/GitHub\/etc\/..\/\/src\/\/Schema\/RepositoryRuleset\/Rules\/Fifteen.php",
-                "hash": "214e7acc22366b3ef365928c3076c397"
+                "hash": "76594874c0e427d6dd005cb9278d4d4b"
             },
             {
                 "name": ".\/clients\/GitHub\/etc\/..\/\/src\/\/Schema\/RepositoryRuleset\/Rules\/Fifteen\/Parameters.php",
@@ -29188,7 +29188,7 @@
             },
             {
                 "name": ".\/clients\/GitHub\/etc\/..\/\/src\/\/Schema\/RepositoryRuleset\/Rules\/Sixteen.php",
-                "hash": "ac1935a5ff7fc89f0928bc7bb5cc3f9c"
+                "hash": "d974a5ceb0c5edb7809951da446ee867"
             },
             {
                 "name": ".\/clients\/GitHub\/etc\/..\/\/src\/\/Schema\/RepositoryRuleset\/Rules\/Sixteen\/Parameters.php",
@@ -29196,7 +29196,7 @@
             },
             {
                 "name": ".\/clients\/GitHub\/etc\/..\/\/src\/\/Schema\/RepositoryRuleset\/Rules\/Seventeen.php",
-                "hash": "ba7299eea13a40b23eba8ea1c9e90b31"
+                "hash": "84cc0841df7a59bae4f6e9fbdccf5b30"
             },
             {
                 "name": ".\/clients\/GitHub\/etc\/..\/\/src\/\/Schema\/RepositoryRuleset\/Rules\/Seventeen\/Parameters.php",
@@ -30248,7 +30248,7 @@
             },
             {
                 "name": ".\/clients\/GitHub\/etc\/..\/\/src\/\/Schema\/RepositoryRuleset\/Rules\/Eighteen.php",
-                "hash": "718d8afbab87adbf7bba94ab60a426e9"
+                "hash": "1e783da3450dd6c6e9c4bd5f1bb3dfcd"
             },
             {
                 "name": ".\/clients\/GitHub\/etc\/..\/\/src\/\/Schema\/RepositoryRuleset\/Rules\/Eighteen\/Parameters.php",

--- a/clients/GitHub/src/Schema/Repos/CreateOrgRuleset/Request/ApplicationJson.php
+++ b/clients/GitHub/src/Schema/Repos/CreateOrgRuleset/Request/ApplicationJson.php
@@ -28,7 +28,7 @@ final readonly class ApplicationJson
                 "push"
             ],
             "type": "string",
-            "description": "The target of the ruleset\\n\\n> [!NOTE]\\n> The `push` target is in beta and is subject to change.",
+            "description": "The target of the ruleset",
             "default": "branch"
         },
         "enforcement": {
@@ -916,7 +916,7 @@ final readonly class ApplicationJson
                                 }
                             }
                         },
-                        "description": "> [!NOTE]\\n> `file_path_restriction` is in beta and subject to change.\\n\\nPrevent commits that include changes in specified file paths from being pushed to the commit graph."
+                        "description": "Prevent commits that include changes in specified file paths from being pushed to the commit graph."
                     },
                     {
                         "title": "max_file_path_length",
@@ -946,7 +946,7 @@ final readonly class ApplicationJson
                                 }
                             }
                         },
-                        "description": "> [!NOTE]\\n> `max_file_path_length` is in beta and subject to change.\\n\\nPrevent commits that include file paths that exceed a specified character limit from being pushed to the commit graph."
+                        "description": "Prevent commits that include file paths that exceed a specified character limit from being pushed to the commit graph."
                     },
                     {
                         "title": "file_extension_restriction",
@@ -977,7 +977,7 @@ final readonly class ApplicationJson
                                 }
                             }
                         },
-                        "description": "> [!NOTE]\\n> `file_extension_restriction` is in beta and subject to change.\\n\\nPrevent commits that include files with specified file extensions from being pushed to the commit graph."
+                        "description": "Prevent commits that include files with specified file extensions from being pushed to the commit graph."
                     },
                     {
                         "title": "max_file_size",
@@ -1007,7 +1007,7 @@ final readonly class ApplicationJson
                                 }
                             }
                         },
-                        "description": "> [!NOTE]\\n> `max_file_size` is in beta and subject to change.\\n\\nPrevent commits that exceed a specified file size limit from being pushed to the commit."
+                        "description": "Prevent commits that exceed a specified file size limit from being pushed to the commit."
                     },
                     {
                         "title": "workflows",
@@ -1168,9 +1168,6 @@ final readonly class ApplicationJson
     /**
      * name: The name of the ruleset.
      * target: The target of the ruleset
-
-    > [!NOTE]
-    > The `push` target is in beta and is subject to change.
      * enforcement: The enforcement level of the ruleset. `evaluate` allows admins to test rules before enforcing them. Admins can view insights on the Rule Insights page (`evaluate` is only available with GitHub Enterprise).
      * bypassActors: The actors that can bypass the rules in this ruleset
      * conditions: Conditions for an organization ruleset. The conditions object should contain both `repository_name` and `ref_name` properties or both `repository_id` and `ref_name` properties.

--- a/clients/GitHub/src/Schema/Repos/CreateRepoRuleset/Request/ApplicationJson.php
+++ b/clients/GitHub/src/Schema/Repos/CreateRepoRuleset/Request/ApplicationJson.php
@@ -27,7 +27,7 @@ final readonly class ApplicationJson
                 "push"
             ],
             "type": "string",
-            "description": "The target of the ruleset\\n\\n> [!NOTE]\\n> The `push` target is in beta and is subject to change.",
+            "description": "The target of the ruleset",
             "default": "branch"
         },
         "enforcement": {
@@ -697,7 +697,7 @@ final readonly class ApplicationJson
                                 }
                             }
                         },
-                        "description": "> [!NOTE]\\n> `file_path_restriction` is in beta and subject to change.\\n\\nPrevent commits that include changes in specified file paths from being pushed to the commit graph."
+                        "description": "Prevent commits that include changes in specified file paths from being pushed to the commit graph."
                     },
                     {
                         "title": "max_file_path_length",
@@ -727,7 +727,7 @@ final readonly class ApplicationJson
                                 }
                             }
                         },
-                        "description": "> [!NOTE]\\n> `max_file_path_length` is in beta and subject to change.\\n\\nPrevent commits that include file paths that exceed a specified character limit from being pushed to the commit graph."
+                        "description": "Prevent commits that include file paths that exceed a specified character limit from being pushed to the commit graph."
                     },
                     {
                         "title": "file_extension_restriction",
@@ -758,7 +758,7 @@ final readonly class ApplicationJson
                                 }
                             }
                         },
-                        "description": "> [!NOTE]\\n> `file_extension_restriction` is in beta and subject to change.\\n\\nPrevent commits that include files with specified file extensions from being pushed to the commit graph."
+                        "description": "Prevent commits that include files with specified file extensions from being pushed to the commit graph."
                     },
                     {
                         "title": "max_file_size",
@@ -788,7 +788,7 @@ final readonly class ApplicationJson
                                 }
                             }
                         },
-                        "description": "> [!NOTE]\\n> `max_file_size` is in beta and subject to change.\\n\\nPrevent commits that exceed a specified file size limit from being pushed to the commit."
+                        "description": "Prevent commits that exceed a specified file size limit from being pushed to the commit."
                     },
                     {
                         "title": "workflows",
@@ -960,9 +960,6 @@ final readonly class ApplicationJson
     /**
      * name: The name of the ruleset.
      * target: The target of the ruleset
-
-    > [!NOTE]
-    > The `push` target is in beta and is subject to change.
      * enforcement: The enforcement level of the ruleset. `evaluate` allows admins to test rules before enforcing them. Admins can view insights on the Rule Insights page (`evaluate` is only available with GitHub Enterprise).
      * bypassActors: The actors that can bypass the rules in this ruleset
      * conditions: Parameters for a repository ruleset ref name condition

--- a/clients/GitHub/src/Schema/Repos/UpdateOrgRuleset/Request/ApplicationJson.php
+++ b/clients/GitHub/src/Schema/Repos/UpdateOrgRuleset/Request/ApplicationJson.php
@@ -24,7 +24,7 @@ final readonly class ApplicationJson
                 "push"
             ],
             "type": "string",
-            "description": "The target of the ruleset\\n\\n> [!NOTE]\\n> The `push` target is in beta and is subject to change."
+            "description": "The target of the ruleset"
         },
         "enforcement": {
             "enum": [
@@ -911,7 +911,7 @@ final readonly class ApplicationJson
                                 }
                             }
                         },
-                        "description": "> [!NOTE]\\n> `file_path_restriction` is in beta and subject to change.\\n\\nPrevent commits that include changes in specified file paths from being pushed to the commit graph."
+                        "description": "Prevent commits that include changes in specified file paths from being pushed to the commit graph."
                     },
                     {
                         "title": "max_file_path_length",
@@ -941,7 +941,7 @@ final readonly class ApplicationJson
                                 }
                             }
                         },
-                        "description": "> [!NOTE]\\n> `max_file_path_length` is in beta and subject to change.\\n\\nPrevent commits that include file paths that exceed a specified character limit from being pushed to the commit graph."
+                        "description": "Prevent commits that include file paths that exceed a specified character limit from being pushed to the commit graph."
                     },
                     {
                         "title": "file_extension_restriction",
@@ -972,7 +972,7 @@ final readonly class ApplicationJson
                                 }
                             }
                         },
-                        "description": "> [!NOTE]\\n> `file_extension_restriction` is in beta and subject to change.\\n\\nPrevent commits that include files with specified file extensions from being pushed to the commit graph."
+                        "description": "Prevent commits that include files with specified file extensions from being pushed to the commit graph."
                     },
                     {
                         "title": "max_file_size",
@@ -1002,7 +1002,7 @@ final readonly class ApplicationJson
                                 }
                             }
                         },
-                        "description": "> [!NOTE]\\n> `max_file_size` is in beta and subject to change.\\n\\nPrevent commits that exceed a specified file size limit from being pushed to the commit."
+                        "description": "Prevent commits that exceed a specified file size limit from being pushed to the commit."
                     },
                     {
                         "title": "workflows",
@@ -1163,9 +1163,6 @@ final readonly class ApplicationJson
     /**
      * name: The name of the ruleset.
      * target: The target of the ruleset
-
-    > [!NOTE]
-    > The `push` target is in beta and is subject to change.
      * enforcement: The enforcement level of the ruleset. `evaluate` allows admins to test rules before enforcing them. Admins can view insights on the Rule Insights page (`evaluate` is only available with GitHub Enterprise).
      * bypassActors: The actors that can bypass the rules in this ruleset
      * conditions: Conditions for an organization ruleset. The conditions object should contain both `repository_name` and `ref_name` properties or both `repository_id` and `ref_name` properties.

--- a/clients/GitHub/src/Schema/Repos/UpdateRepoRuleset/Request/ApplicationJson.php
+++ b/clients/GitHub/src/Schema/Repos/UpdateRepoRuleset/Request/ApplicationJson.php
@@ -23,7 +23,7 @@ final readonly class ApplicationJson
                 "push"
             ],
             "type": "string",
-            "description": "The target of the ruleset\\n\\n> [!NOTE]\\n> The `push` target is in beta and is subject to change."
+            "description": "The target of the ruleset"
         },
         "enforcement": {
             "enum": [
@@ -692,7 +692,7 @@ final readonly class ApplicationJson
                                 }
                             }
                         },
-                        "description": "> [!NOTE]\\n> `file_path_restriction` is in beta and subject to change.\\n\\nPrevent commits that include changes in specified file paths from being pushed to the commit graph."
+                        "description": "Prevent commits that include changes in specified file paths from being pushed to the commit graph."
                     },
                     {
                         "title": "max_file_path_length",
@@ -722,7 +722,7 @@ final readonly class ApplicationJson
                                 }
                             }
                         },
-                        "description": "> [!NOTE]\\n> `max_file_path_length` is in beta and subject to change.\\n\\nPrevent commits that include file paths that exceed a specified character limit from being pushed to the commit graph."
+                        "description": "Prevent commits that include file paths that exceed a specified character limit from being pushed to the commit graph."
                     },
                     {
                         "title": "file_extension_restriction",
@@ -753,7 +753,7 @@ final readonly class ApplicationJson
                                 }
                             }
                         },
-                        "description": "> [!NOTE]\\n> `file_extension_restriction` is in beta and subject to change.\\n\\nPrevent commits that include files with specified file extensions from being pushed to the commit graph."
+                        "description": "Prevent commits that include files with specified file extensions from being pushed to the commit graph."
                     },
                     {
                         "title": "max_file_size",
@@ -783,7 +783,7 @@ final readonly class ApplicationJson
                                 }
                             }
                         },
-                        "description": "> [!NOTE]\\n> `max_file_size` is in beta and subject to change.\\n\\nPrevent commits that exceed a specified file size limit from being pushed to the commit."
+                        "description": "Prevent commits that exceed a specified file size limit from being pushed to the commit."
                     },
                     {
                         "title": "workflows",
@@ -955,9 +955,6 @@ final readonly class ApplicationJson
     /**
      * name: The name of the ruleset.
      * target: The target of the ruleset
-
-    > [!NOTE]
-    > The `push` target is in beta and is subject to change.
      * enforcement: The enforcement level of the ruleset. `evaluate` allows admins to test rules before enforcing them. Admins can view insights on the Rule Insights page (`evaluate` is only available with GitHub Enterprise).
      * bypassActors: The actors that can bypass the rules in this ruleset
      * conditions: Parameters for a repository ruleset ref name condition

--- a/clients/GitHub/src/Schema/RepositoryRule.php
+++ b/clients/GitHub/src/Schema/RepositoryRule.php
@@ -595,7 +595,7 @@ final readonly class RepositoryRule
                     }
                 }
             },
-            "description": "> [!NOTE]\\n> `file_path_restriction` is in beta and subject to change.\\n\\nPrevent commits that include changes in specified file paths from being pushed to the commit graph."
+            "description": "Prevent commits that include changes in specified file paths from being pushed to the commit graph."
         },
         {
             "title": "max_file_path_length",
@@ -625,7 +625,7 @@ final readonly class RepositoryRule
                     }
                 }
             },
-            "description": "> [!NOTE]\\n> `max_file_path_length` is in beta and subject to change.\\n\\nPrevent commits that include file paths that exceed a specified character limit from being pushed to the commit graph."
+            "description": "Prevent commits that include file paths that exceed a specified character limit from being pushed to the commit graph."
         },
         {
             "title": "file_extension_restriction",
@@ -656,7 +656,7 @@ final readonly class RepositoryRule
                     }
                 }
             },
-            "description": "> [!NOTE]\\n> `file_extension_restriction` is in beta and subject to change.\\n\\nPrevent commits that include files with specified file extensions from being pushed to the commit graph."
+            "description": "Prevent commits that include files with specified file extensions from being pushed to the commit graph."
         },
         {
             "title": "max_file_size",
@@ -686,7 +686,7 @@ final readonly class RepositoryRule
                     }
                 }
             },
-            "description": "> [!NOTE]\\n> `max_file_size` is in beta and subject to change.\\n\\nPrevent commits that exceed a specified file size limit from being pushed to the commit."
+            "description": "Prevent commits that exceed a specified file size limit from being pushed to the commit."
         },
         {
             "title": "workflows",

--- a/clients/GitHub/src/Schema/RepositoryRuleset.php
+++ b/clients/GitHub/src/Schema/RepositoryRuleset.php
@@ -35,7 +35,7 @@ final readonly class RepositoryRuleset
                 "push"
             ],
             "type": "string",
-            "description": "The target of the ruleset\\n\\n> [!NOTE]\\n> The `push` target is in beta and is subject to change."
+            "description": "The target of the ruleset"
         },
         "source_type": {
             "enum": [
@@ -1003,7 +1003,7 @@ final readonly class RepositoryRuleset
                                 }
                             }
                         },
-                        "description": "> [!NOTE]\\n> `file_path_restriction` is in beta and subject to change.\\n\\nPrevent commits that include changes in specified file paths from being pushed to the commit graph."
+                        "description": "Prevent commits that include changes in specified file paths from being pushed to the commit graph."
                     },
                     {
                         "title": "max_file_path_length",
@@ -1033,7 +1033,7 @@ final readonly class RepositoryRuleset
                                 }
                             }
                         },
-                        "description": "> [!NOTE]\\n> `max_file_path_length` is in beta and subject to change.\\n\\nPrevent commits that include file paths that exceed a specified character limit from being pushed to the commit graph."
+                        "description": "Prevent commits that include file paths that exceed a specified character limit from being pushed to the commit graph."
                     },
                     {
                         "title": "file_extension_restriction",
@@ -1064,7 +1064,7 @@ final readonly class RepositoryRuleset
                                 }
                             }
                         },
-                        "description": "> [!NOTE]\\n> `file_extension_restriction` is in beta and subject to change.\\n\\nPrevent commits that include files with specified file extensions from being pushed to the commit graph."
+                        "description": "Prevent commits that include files with specified file extensions from being pushed to the commit graph."
                     },
                     {
                         "title": "max_file_size",
@@ -1094,7 +1094,7 @@ final readonly class RepositoryRuleset
                                 }
                             }
                         },
-                        "description": "> [!NOTE]\\n> `max_file_size` is in beta and subject to change.\\n\\nPrevent commits that exceed a specified file size limit from being pushed to the commit."
+                        "description": "Prevent commits that exceed a specified file size limit from being pushed to the commit."
                     },
                     {
                         "title": "workflows",
@@ -1279,9 +1279,6 @@ final readonly class RepositoryRuleset
      * id: The ID of the ruleset
      * name: The name of the ruleset
      * target: The target of the ruleset
-
-    > [!NOTE]
-    > The `push` target is in beta and is subject to change.
      * sourceType: The type of the source of the ruleset
      * source: The name of the source
      * enforcement: The enforcement level of the ruleset. `evaluate` allows admins to test rules before enforcing them. Admins can view insights on the Rule Insights page (`evaluate` is only available with GitHub Enterprise).

--- a/clients/GitHub/src/Schema/RepositoryRuleset/Rules/Eighteen.php
+++ b/clients/GitHub/src/Schema/RepositoryRuleset/Rules/Eighteen.php
@@ -36,13 +36,10 @@ final readonly class Eighteen
             }
         }
     },
-    "description": "> [!NOTE]\\n> `max_file_size` is in beta and subject to change.\\n\\nPrevent commits that exceed a specified file size limit from being pushed to the commit."
+    "description": "Prevent commits that exceed a specified file size limit from being pushed to the commit."
 }';
     public const SCHEMA_TITLE        = 'max_file_size';
-    public const SCHEMA_DESCRIPTION  = '> [!NOTE]
-> `max_file_size` is in beta and subject to change.
-
-Prevent commits that exceed a specified file size limit from being pushed to the commit.';
+    public const SCHEMA_DESCRIPTION  = 'Prevent commits that exceed a specified file size limit from being pushed to the commit.';
     public const SCHEMA_EXAMPLE_DATA = '{
     "type": "max_file_size",
     "parameters": {

--- a/clients/GitHub/src/Schema/RepositoryRuleset/Rules/Fifteen.php
+++ b/clients/GitHub/src/Schema/RepositoryRuleset/Rules/Fifteen.php
@@ -37,13 +37,10 @@ final readonly class Fifteen
             }
         }
     },
-    "description": "> [!NOTE]\\n> `file_path_restriction` is in beta and subject to change.\\n\\nPrevent commits that include changes in specified file paths from being pushed to the commit graph."
+    "description": "Prevent commits that include changes in specified file paths from being pushed to the commit graph."
 }';
     public const SCHEMA_TITLE        = 'file_path_restriction';
-    public const SCHEMA_DESCRIPTION  = '> [!NOTE]
-> `file_path_restriction` is in beta and subject to change.
-
-Prevent commits that include changes in specified file paths from being pushed to the commit graph.';
+    public const SCHEMA_DESCRIPTION  = 'Prevent commits that include changes in specified file paths from being pushed to the commit graph.';
     public const SCHEMA_EXAMPLE_DATA = '{
     "type": "file_path_restriction",
     "parameters": {

--- a/clients/GitHub/src/Schema/RepositoryRuleset/Rules/Seventeen.php
+++ b/clients/GitHub/src/Schema/RepositoryRuleset/Rules/Seventeen.php
@@ -37,13 +37,10 @@ final readonly class Seventeen
             }
         }
     },
-    "description": "> [!NOTE]\\n> `file_extension_restriction` is in beta and subject to change.\\n\\nPrevent commits that include files with specified file extensions from being pushed to the commit graph."
+    "description": "Prevent commits that include files with specified file extensions from being pushed to the commit graph."
 }';
     public const SCHEMA_TITLE        = 'file_extension_restriction';
-    public const SCHEMA_DESCRIPTION  = '> [!NOTE]
-> `file_extension_restriction` is in beta and subject to change.
-
-Prevent commits that include files with specified file extensions from being pushed to the commit graph.';
+    public const SCHEMA_DESCRIPTION  = 'Prevent commits that include files with specified file extensions from being pushed to the commit graph.';
     public const SCHEMA_EXAMPLE_DATA = '{
     "type": "file_extension_restriction",
     "parameters": {

--- a/clients/GitHub/src/Schema/RepositoryRuleset/Rules/Sixteen.php
+++ b/clients/GitHub/src/Schema/RepositoryRuleset/Rules/Sixteen.php
@@ -36,13 +36,10 @@ final readonly class Sixteen
             }
         }
     },
-    "description": "> [!NOTE]\\n> `max_file_path_length` is in beta and subject to change.\\n\\nPrevent commits that include file paths that exceed a specified character limit from being pushed to the commit graph."
+    "description": "Prevent commits that include file paths that exceed a specified character limit from being pushed to the commit graph."
 }';
     public const SCHEMA_TITLE        = 'max_file_path_length';
-    public const SCHEMA_DESCRIPTION  = '> [!NOTE]
-> `max_file_path_length` is in beta and subject to change.
-
-Prevent commits that include file paths that exceed a specified character limit from being pushed to the commit graph.';
+    public const SCHEMA_DESCRIPTION  = 'Prevent commits that include file paths that exceed a specified character limit from being pushed to the commit graph.';
     public const SCHEMA_EXAMPLE_DATA = '{
     "type": "max_file_path_length",
     "parameters": {

--- a/clients/GitHub/src/Schema/WebhookRepositoryRulesetCreated.php
+++ b/clients/GitHub/src/Schema/WebhookRepositoryRulesetCreated.php
@@ -1740,7 +1740,7 @@ final readonly class WebhookRepositoryRulesetCreated
                         "push"
                     ],
                     "type": "string",
-                    "description": "The target of the ruleset\\n\\n> [!NOTE]\\n> The `push` target is in beta and is subject to change."
+                    "description": "The target of the ruleset"
                 },
                 "source_type": {
                     "enum": [
@@ -2708,7 +2708,7 @@ final readonly class WebhookRepositoryRulesetCreated
                                         }
                                     }
                                 },
-                                "description": "> [!NOTE]\\n> `file_path_restriction` is in beta and subject to change.\\n\\nPrevent commits that include changes in specified file paths from being pushed to the commit graph."
+                                "description": "Prevent commits that include changes in specified file paths from being pushed to the commit graph."
                             },
                             {
                                 "title": "max_file_path_length",
@@ -2738,7 +2738,7 @@ final readonly class WebhookRepositoryRulesetCreated
                                         }
                                     }
                                 },
-                                "description": "> [!NOTE]\\n> `max_file_path_length` is in beta and subject to change.\\n\\nPrevent commits that include file paths that exceed a specified character limit from being pushed to the commit graph."
+                                "description": "Prevent commits that include file paths that exceed a specified character limit from being pushed to the commit graph."
                             },
                             {
                                 "title": "file_extension_restriction",
@@ -2769,7 +2769,7 @@ final readonly class WebhookRepositoryRulesetCreated
                                         }
                                     }
                                 },
-                                "description": "> [!NOTE]\\n> `file_extension_restriction` is in beta and subject to change.\\n\\nPrevent commits that include files with specified file extensions from being pushed to the commit graph."
+                                "description": "Prevent commits that include files with specified file extensions from being pushed to the commit graph."
                             },
                             {
                                 "title": "max_file_size",
@@ -2799,7 +2799,7 @@ final readonly class WebhookRepositoryRulesetCreated
                                         }
                                     }
                                 },
-                                "description": "> [!NOTE]\\n> `max_file_size` is in beta and subject to change.\\n\\nPrevent commits that exceed a specified file size limit from being pushed to the commit."
+                                "description": "Prevent commits that exceed a specified file size limit from being pushed to the commit."
                             },
                             {
                                 "title": "workflows",

--- a/clients/GitHub/src/Schema/WebhookRepositoryRulesetDeleted.php
+++ b/clients/GitHub/src/Schema/WebhookRepositoryRulesetDeleted.php
@@ -1740,7 +1740,7 @@ final readonly class WebhookRepositoryRulesetDeleted
                         "push"
                     ],
                     "type": "string",
-                    "description": "The target of the ruleset\\n\\n> [!NOTE]\\n> The `push` target is in beta and is subject to change."
+                    "description": "The target of the ruleset"
                 },
                 "source_type": {
                     "enum": [
@@ -2708,7 +2708,7 @@ final readonly class WebhookRepositoryRulesetDeleted
                                         }
                                     }
                                 },
-                                "description": "> [!NOTE]\\n> `file_path_restriction` is in beta and subject to change.\\n\\nPrevent commits that include changes in specified file paths from being pushed to the commit graph."
+                                "description": "Prevent commits that include changes in specified file paths from being pushed to the commit graph."
                             },
                             {
                                 "title": "max_file_path_length",
@@ -2738,7 +2738,7 @@ final readonly class WebhookRepositoryRulesetDeleted
                                         }
                                     }
                                 },
-                                "description": "> [!NOTE]\\n> `max_file_path_length` is in beta and subject to change.\\n\\nPrevent commits that include file paths that exceed a specified character limit from being pushed to the commit graph."
+                                "description": "Prevent commits that include file paths that exceed a specified character limit from being pushed to the commit graph."
                             },
                             {
                                 "title": "file_extension_restriction",
@@ -2769,7 +2769,7 @@ final readonly class WebhookRepositoryRulesetDeleted
                                         }
                                     }
                                 },
-                                "description": "> [!NOTE]\\n> `file_extension_restriction` is in beta and subject to change.\\n\\nPrevent commits that include files with specified file extensions from being pushed to the commit graph."
+                                "description": "Prevent commits that include files with specified file extensions from being pushed to the commit graph."
                             },
                             {
                                 "title": "max_file_size",
@@ -2799,7 +2799,7 @@ final readonly class WebhookRepositoryRulesetDeleted
                                         }
                                     }
                                 },
-                                "description": "> [!NOTE]\\n> `max_file_size` is in beta and subject to change.\\n\\nPrevent commits that exceed a specified file size limit from being pushed to the commit."
+                                "description": "Prevent commits that exceed a specified file size limit from being pushed to the commit."
                             },
                             {
                                 "title": "workflows",

--- a/clients/GitHub/src/Schema/WebhookRepositoryRulesetEdited.php
+++ b/clients/GitHub/src/Schema/WebhookRepositoryRulesetEdited.php
@@ -1740,7 +1740,7 @@ final readonly class WebhookRepositoryRulesetEdited
                         "push"
                     ],
                     "type": "string",
-                    "description": "The target of the ruleset\\n\\n> [!NOTE]\\n> The `push` target is in beta and is subject to change."
+                    "description": "The target of the ruleset"
                 },
                 "source_type": {
                     "enum": [
@@ -2708,7 +2708,7 @@ final readonly class WebhookRepositoryRulesetEdited
                                         }
                                     }
                                 },
-                                "description": "> [!NOTE]\\n> `file_path_restriction` is in beta and subject to change.\\n\\nPrevent commits that include changes in specified file paths from being pushed to the commit graph."
+                                "description": "Prevent commits that include changes in specified file paths from being pushed to the commit graph."
                             },
                             {
                                 "title": "max_file_path_length",
@@ -2738,7 +2738,7 @@ final readonly class WebhookRepositoryRulesetEdited
                                         }
                                     }
                                 },
-                                "description": "> [!NOTE]\\n> `max_file_path_length` is in beta and subject to change.\\n\\nPrevent commits that include file paths that exceed a specified character limit from being pushed to the commit graph."
+                                "description": "Prevent commits that include file paths that exceed a specified character limit from being pushed to the commit graph."
                             },
                             {
                                 "title": "file_extension_restriction",
@@ -2769,7 +2769,7 @@ final readonly class WebhookRepositoryRulesetEdited
                                         }
                                     }
                                 },
-                                "description": "> [!NOTE]\\n> `file_extension_restriction` is in beta and subject to change.\\n\\nPrevent commits that include files with specified file extensions from being pushed to the commit graph."
+                                "description": "Prevent commits that include files with specified file extensions from being pushed to the commit graph."
                             },
                             {
                                 "title": "max_file_size",
@@ -2799,7 +2799,7 @@ final readonly class WebhookRepositoryRulesetEdited
                                         }
                                     }
                                 },
-                                "description": "> [!NOTE]\\n> `max_file_size` is in beta and subject to change.\\n\\nPrevent commits that exceed a specified file size limit from being pushed to the commit."
+                                "description": "Prevent commits that exceed a specified file size limit from being pushed to the commit."
                             },
                             {
                                 "title": "workflows",
@@ -3693,7 +3693,7 @@ final readonly class WebhookRepositoryRulesetEdited
                                                 }
                                             }
                                         },
-                                        "description": "> [!NOTE]\\n> `file_path_restriction` is in beta and subject to change.\\n\\nPrevent commits that include changes in specified file paths from being pushed to the commit graph."
+                                        "description": "Prevent commits that include changes in specified file paths from being pushed to the commit graph."
                                     },
                                     {
                                         "title": "max_file_path_length",
@@ -3723,7 +3723,7 @@ final readonly class WebhookRepositoryRulesetEdited
                                                 }
                                             }
                                         },
-                                        "description": "> [!NOTE]\\n> `max_file_path_length` is in beta and subject to change.\\n\\nPrevent commits that include file paths that exceed a specified character limit from being pushed to the commit graph."
+                                        "description": "Prevent commits that include file paths that exceed a specified character limit from being pushed to the commit graph."
                                     },
                                     {
                                         "title": "file_extension_restriction",
@@ -3754,7 +3754,7 @@ final readonly class WebhookRepositoryRulesetEdited
                                                 }
                                             }
                                         },
-                                        "description": "> [!NOTE]\\n> `file_extension_restriction` is in beta and subject to change.\\n\\nPrevent commits that include files with specified file extensions from being pushed to the commit graph."
+                                        "description": "Prevent commits that include files with specified file extensions from being pushed to the commit graph."
                                     },
                                     {
                                         "title": "max_file_size",
@@ -3784,7 +3784,7 @@ final readonly class WebhookRepositoryRulesetEdited
                                                 }
                                             }
                                         },
-                                        "description": "> [!NOTE]\\n> `max_file_size` is in beta and subject to change.\\n\\nPrevent commits that exceed a specified file size limit from being pushed to the commit."
+                                        "description": "Prevent commits that exceed a specified file size limit from being pushed to the commit."
                                     },
                                     {
                                         "title": "workflows",
@@ -4505,7 +4505,7 @@ final readonly class WebhookRepositoryRulesetEdited
                                                 }
                                             }
                                         },
-                                        "description": "> [!NOTE]\\n> `file_path_restriction` is in beta and subject to change.\\n\\nPrevent commits that include changes in specified file paths from being pushed to the commit graph."
+                                        "description": "Prevent commits that include changes in specified file paths from being pushed to the commit graph."
                                     },
                                     {
                                         "title": "max_file_path_length",
@@ -4535,7 +4535,7 @@ final readonly class WebhookRepositoryRulesetEdited
                                                 }
                                             }
                                         },
-                                        "description": "> [!NOTE]\\n> `max_file_path_length` is in beta and subject to change.\\n\\nPrevent commits that include file paths that exceed a specified character limit from being pushed to the commit graph."
+                                        "description": "Prevent commits that include file paths that exceed a specified character limit from being pushed to the commit graph."
                                     },
                                     {
                                         "title": "file_extension_restriction",
@@ -4566,7 +4566,7 @@ final readonly class WebhookRepositoryRulesetEdited
                                                 }
                                             }
                                         },
-                                        "description": "> [!NOTE]\\n> `file_extension_restriction` is in beta and subject to change.\\n\\nPrevent commits that include files with specified file extensions from being pushed to the commit graph."
+                                        "description": "Prevent commits that include files with specified file extensions from being pushed to the commit graph."
                                     },
                                     {
                                         "title": "max_file_size",
@@ -4596,7 +4596,7 @@ final readonly class WebhookRepositoryRulesetEdited
                                                 }
                                             }
                                         },
-                                        "description": "> [!NOTE]\\n> `max_file_size` is in beta and subject to change.\\n\\nPrevent commits that exceed a specified file size limit from being pushed to the commit."
+                                        "description": "Prevent commits that exceed a specified file size limit from being pushed to the commit."
                                     },
                                     {
                                         "title": "workflows",
@@ -5320,7 +5320,7 @@ final readonly class WebhookRepositoryRulesetEdited
                                                         }
                                                     }
                                                 },
-                                                "description": "> [!NOTE]\\n> `file_path_restriction` is in beta and subject to change.\\n\\nPrevent commits that include changes in specified file paths from being pushed to the commit graph."
+                                                "description": "Prevent commits that include changes in specified file paths from being pushed to the commit graph."
                                             },
                                             {
                                                 "title": "max_file_path_length",
@@ -5350,7 +5350,7 @@ final readonly class WebhookRepositoryRulesetEdited
                                                         }
                                                     }
                                                 },
-                                                "description": "> [!NOTE]\\n> `max_file_path_length` is in beta and subject to change.\\n\\nPrevent commits that include file paths that exceed a specified character limit from being pushed to the commit graph."
+                                                "description": "Prevent commits that include file paths that exceed a specified character limit from being pushed to the commit graph."
                                             },
                                             {
                                                 "title": "file_extension_restriction",
@@ -5381,7 +5381,7 @@ final readonly class WebhookRepositoryRulesetEdited
                                                         }
                                                     }
                                                 },
-                                                "description": "> [!NOTE]\\n> `file_extension_restriction` is in beta and subject to change.\\n\\nPrevent commits that include files with specified file extensions from being pushed to the commit graph."
+                                                "description": "Prevent commits that include files with specified file extensions from being pushed to the commit graph."
                                             },
                                             {
                                                 "title": "max_file_size",
@@ -5411,7 +5411,7 @@ final readonly class WebhookRepositoryRulesetEdited
                                                         }
                                                     }
                                                 },
-                                                "description": "> [!NOTE]\\n> `max_file_size` is in beta and subject to change.\\n\\nPrevent commits that exceed a specified file size limit from being pushed to the commit."
+                                                "description": "Prevent commits that exceed a specified file size limit from being pushed to the commit."
                                             },
                                             {
                                                 "title": "workflows",

--- a/clients/GitHub/src/Schema/WebhookRepositoryRulesetEdited/Changes.php
+++ b/clients/GitHub/src/Schema/WebhookRepositoryRulesetEdited/Changes.php
@@ -761,7 +761,7 @@ final readonly class Changes
                                         }
                                     }
                                 },
-                                "description": "> [!NOTE]\\n> `file_path_restriction` is in beta and subject to change.\\n\\nPrevent commits that include changes in specified file paths from being pushed to the commit graph."
+                                "description": "Prevent commits that include changes in specified file paths from being pushed to the commit graph."
                             },
                             {
                                 "title": "max_file_path_length",
@@ -791,7 +791,7 @@ final readonly class Changes
                                         }
                                     }
                                 },
-                                "description": "> [!NOTE]\\n> `max_file_path_length` is in beta and subject to change.\\n\\nPrevent commits that include file paths that exceed a specified character limit from being pushed to the commit graph."
+                                "description": "Prevent commits that include file paths that exceed a specified character limit from being pushed to the commit graph."
                             },
                             {
                                 "title": "file_extension_restriction",
@@ -822,7 +822,7 @@ final readonly class Changes
                                         }
                                     }
                                 },
-                                "description": "> [!NOTE]\\n> `file_extension_restriction` is in beta and subject to change.\\n\\nPrevent commits that include files with specified file extensions from being pushed to the commit graph."
+                                "description": "Prevent commits that include files with specified file extensions from being pushed to the commit graph."
                             },
                             {
                                 "title": "max_file_size",
@@ -852,7 +852,7 @@ final readonly class Changes
                                         }
                                     }
                                 },
-                                "description": "> [!NOTE]\\n> `max_file_size` is in beta and subject to change.\\n\\nPrevent commits that exceed a specified file size limit from being pushed to the commit."
+                                "description": "Prevent commits that exceed a specified file size limit from being pushed to the commit."
                             },
                             {
                                 "title": "workflows",
@@ -1573,7 +1573,7 @@ final readonly class Changes
                                         }
                                     }
                                 },
-                                "description": "> [!NOTE]\\n> `file_path_restriction` is in beta and subject to change.\\n\\nPrevent commits that include changes in specified file paths from being pushed to the commit graph."
+                                "description": "Prevent commits that include changes in specified file paths from being pushed to the commit graph."
                             },
                             {
                                 "title": "max_file_path_length",
@@ -1603,7 +1603,7 @@ final readonly class Changes
                                         }
                                     }
                                 },
-                                "description": "> [!NOTE]\\n> `max_file_path_length` is in beta and subject to change.\\n\\nPrevent commits that include file paths that exceed a specified character limit from being pushed to the commit graph."
+                                "description": "Prevent commits that include file paths that exceed a specified character limit from being pushed to the commit graph."
                             },
                             {
                                 "title": "file_extension_restriction",
@@ -1634,7 +1634,7 @@ final readonly class Changes
                                         }
                                     }
                                 },
-                                "description": "> [!NOTE]\\n> `file_extension_restriction` is in beta and subject to change.\\n\\nPrevent commits that include files with specified file extensions from being pushed to the commit graph."
+                                "description": "Prevent commits that include files with specified file extensions from being pushed to the commit graph."
                             },
                             {
                                 "title": "max_file_size",
@@ -1664,7 +1664,7 @@ final readonly class Changes
                                         }
                                     }
                                 },
-                                "description": "> [!NOTE]\\n> `max_file_size` is in beta and subject to change.\\n\\nPrevent commits that exceed a specified file size limit from being pushed to the commit."
+                                "description": "Prevent commits that exceed a specified file size limit from being pushed to the commit."
                             },
                             {
                                 "title": "workflows",
@@ -2388,7 +2388,7 @@ final readonly class Changes
                                                 }
                                             }
                                         },
-                                        "description": "> [!NOTE]\\n> `file_path_restriction` is in beta and subject to change.\\n\\nPrevent commits that include changes in specified file paths from being pushed to the commit graph."
+                                        "description": "Prevent commits that include changes in specified file paths from being pushed to the commit graph."
                                     },
                                     {
                                         "title": "max_file_path_length",
@@ -2418,7 +2418,7 @@ final readonly class Changes
                                                 }
                                             }
                                         },
-                                        "description": "> [!NOTE]\\n> `max_file_path_length` is in beta and subject to change.\\n\\nPrevent commits that include file paths that exceed a specified character limit from being pushed to the commit graph."
+                                        "description": "Prevent commits that include file paths that exceed a specified character limit from being pushed to the commit graph."
                                     },
                                     {
                                         "title": "file_extension_restriction",
@@ -2449,7 +2449,7 @@ final readonly class Changes
                                                 }
                                             }
                                         },
-                                        "description": "> [!NOTE]\\n> `file_extension_restriction` is in beta and subject to change.\\n\\nPrevent commits that include files with specified file extensions from being pushed to the commit graph."
+                                        "description": "Prevent commits that include files with specified file extensions from being pushed to the commit graph."
                                     },
                                     {
                                         "title": "max_file_size",
@@ -2479,7 +2479,7 @@ final readonly class Changes
                                                 }
                                             }
                                         },
-                                        "description": "> [!NOTE]\\n> `max_file_size` is in beta and subject to change.\\n\\nPrevent commits that exceed a specified file size limit from being pushed to the commit."
+                                        "description": "Prevent commits that exceed a specified file size limit from being pushed to the commit."
                                     },
                                     {
                                         "title": "workflows",

--- a/clients/GitHub/src/Schema/WebhookRepositoryRulesetEdited/Changes/Rules.php
+++ b/clients/GitHub/src/Schema/WebhookRepositoryRulesetEdited/Changes/Rules.php
@@ -600,7 +600,7 @@ final readonly class Rules
                                 }
                             }
                         },
-                        "description": "> [!NOTE]\\n> `file_path_restriction` is in beta and subject to change.\\n\\nPrevent commits that include changes in specified file paths from being pushed to the commit graph."
+                        "description": "Prevent commits that include changes in specified file paths from being pushed to the commit graph."
                     },
                     {
                         "title": "max_file_path_length",
@@ -630,7 +630,7 @@ final readonly class Rules
                                 }
                             }
                         },
-                        "description": "> [!NOTE]\\n> `max_file_path_length` is in beta and subject to change.\\n\\nPrevent commits that include file paths that exceed a specified character limit from being pushed to the commit graph."
+                        "description": "Prevent commits that include file paths that exceed a specified character limit from being pushed to the commit graph."
                     },
                     {
                         "title": "file_extension_restriction",
@@ -661,7 +661,7 @@ final readonly class Rules
                                 }
                             }
                         },
-                        "description": "> [!NOTE]\\n> `file_extension_restriction` is in beta and subject to change.\\n\\nPrevent commits that include files with specified file extensions from being pushed to the commit graph."
+                        "description": "Prevent commits that include files with specified file extensions from being pushed to the commit graph."
                     },
                     {
                         "title": "max_file_size",
@@ -691,7 +691,7 @@ final readonly class Rules
                                 }
                             }
                         },
-                        "description": "> [!NOTE]\\n> `max_file_size` is in beta and subject to change.\\n\\nPrevent commits that exceed a specified file size limit from being pushed to the commit."
+                        "description": "Prevent commits that exceed a specified file size limit from being pushed to the commit."
                     },
                     {
                         "title": "workflows",
@@ -1412,7 +1412,7 @@ final readonly class Rules
                                 }
                             }
                         },
-                        "description": "> [!NOTE]\\n> `file_path_restriction` is in beta and subject to change.\\n\\nPrevent commits that include changes in specified file paths from being pushed to the commit graph."
+                        "description": "Prevent commits that include changes in specified file paths from being pushed to the commit graph."
                     },
                     {
                         "title": "max_file_path_length",
@@ -1442,7 +1442,7 @@ final readonly class Rules
                                 }
                             }
                         },
-                        "description": "> [!NOTE]\\n> `max_file_path_length` is in beta and subject to change.\\n\\nPrevent commits that include file paths that exceed a specified character limit from being pushed to the commit graph."
+                        "description": "Prevent commits that include file paths that exceed a specified character limit from being pushed to the commit graph."
                     },
                     {
                         "title": "file_extension_restriction",
@@ -1473,7 +1473,7 @@ final readonly class Rules
                                 }
                             }
                         },
-                        "description": "> [!NOTE]\\n> `file_extension_restriction` is in beta and subject to change.\\n\\nPrevent commits that include files with specified file extensions from being pushed to the commit graph."
+                        "description": "Prevent commits that include files with specified file extensions from being pushed to the commit graph."
                     },
                     {
                         "title": "max_file_size",
@@ -1503,7 +1503,7 @@ final readonly class Rules
                                 }
                             }
                         },
-                        "description": "> [!NOTE]\\n> `max_file_size` is in beta and subject to change.\\n\\nPrevent commits that exceed a specified file size limit from being pushed to the commit."
+                        "description": "Prevent commits that exceed a specified file size limit from being pushed to the commit."
                     },
                     {
                         "title": "workflows",
@@ -2227,7 +2227,7 @@ final readonly class Rules
                                         }
                                     }
                                 },
-                                "description": "> [!NOTE]\\n> `file_path_restriction` is in beta and subject to change.\\n\\nPrevent commits that include changes in specified file paths from being pushed to the commit graph."
+                                "description": "Prevent commits that include changes in specified file paths from being pushed to the commit graph."
                             },
                             {
                                 "title": "max_file_path_length",
@@ -2257,7 +2257,7 @@ final readonly class Rules
                                         }
                                     }
                                 },
-                                "description": "> [!NOTE]\\n> `max_file_path_length` is in beta and subject to change.\\n\\nPrevent commits that include file paths that exceed a specified character limit from being pushed to the commit graph."
+                                "description": "Prevent commits that include file paths that exceed a specified character limit from being pushed to the commit graph."
                             },
                             {
                                 "title": "file_extension_restriction",
@@ -2288,7 +2288,7 @@ final readonly class Rules
                                         }
                                     }
                                 },
-                                "description": "> [!NOTE]\\n> `file_extension_restriction` is in beta and subject to change.\\n\\nPrevent commits that include files with specified file extensions from being pushed to the commit graph."
+                                "description": "Prevent commits that include files with specified file extensions from being pushed to the commit graph."
                             },
                             {
                                 "title": "max_file_size",
@@ -2318,7 +2318,7 @@ final readonly class Rules
                                         }
                                     }
                                 },
-                                "description": "> [!NOTE]\\n> `max_file_size` is in beta and subject to change.\\n\\nPrevent commits that exceed a specified file size limit from being pushed to the commit."
+                                "description": "Prevent commits that exceed a specified file size limit from being pushed to the commit."
                             },
                             {
                                 "title": "workflows",

--- a/clients/GitHub/src/Schema/WebhookRepositoryRulesetEdited/Changes/Rules/Updated.php
+++ b/clients/GitHub/src/Schema/WebhookRepositoryRulesetEdited/Changes/Rules/Updated.php
@@ -601,7 +601,7 @@ final readonly class Updated
                             }
                         }
                     },
-                    "description": "> [!NOTE]\\n> `file_path_restriction` is in beta and subject to change.\\n\\nPrevent commits that include changes in specified file paths from being pushed to the commit graph."
+                    "description": "Prevent commits that include changes in specified file paths from being pushed to the commit graph."
                 },
                 {
                     "title": "max_file_path_length",
@@ -631,7 +631,7 @@ final readonly class Updated
                             }
                         }
                     },
-                    "description": "> [!NOTE]\\n> `max_file_path_length` is in beta and subject to change.\\n\\nPrevent commits that include file paths that exceed a specified character limit from being pushed to the commit graph."
+                    "description": "Prevent commits that include file paths that exceed a specified character limit from being pushed to the commit graph."
                 },
                 {
                     "title": "file_extension_restriction",
@@ -662,7 +662,7 @@ final readonly class Updated
                             }
                         }
                     },
-                    "description": "> [!NOTE]\\n> `file_extension_restriction` is in beta and subject to change.\\n\\nPrevent commits that include files with specified file extensions from being pushed to the commit graph."
+                    "description": "Prevent commits that include files with specified file extensions from being pushed to the commit graph."
                 },
                 {
                     "title": "max_file_size",
@@ -692,7 +692,7 @@ final readonly class Updated
                             }
                         }
                     },
-                    "description": "> [!NOTE]\\n> `max_file_size` is in beta and subject to change.\\n\\nPrevent commits that exceed a specified file size limit from being pushed to the commit."
+                    "description": "Prevent commits that exceed a specified file size limit from being pushed to the commit."
                 },
                 {
                     "title": "workflows",


### PR DESCRIPTION
Detected Schema changes:



```
├─┬Paths
│ ├─┬/repos/{owner}/{repo}/rulesets
│ │ └─┬POST
│ │   └─┬Requestbody
│ │     └─┬application/json
│ │       └─┬Schema
│ │         └─┬target
│ │           └──[🔀] description (37319:32)
│ ├─┬/orgs/{org}/rulesets
│ │ └─┬POST
│ │   └─┬Requestbody
│ │     └─┬application/json
│ │       └─┬Schema
│ │         └─┬target
│ │           └──[🔀] description (12617:32)
│ ├─┬/repos/{owner}/{repo}/rulesets/{ruleset_id}
│ │ └─┬PUT
│ │   └─┬Requestbody
│ │     └─┬application/json
│ │       └─┬Schema
│ │         └─┬target
│ │           └──[🔀] description (37543:32)
│ └─┬/orgs/{org}/rulesets/{ruleset_id}
│   └─┬PUT
│     └─┬Requestbody
│       └─┬application/json
│         └─┬Schema
│           └─┬target
│             └──[🔀] description (12837:32)
└─┬Components
  ├─┬repository-ruleset
  │ └─┬target
  │   └──[🔀] description (74766:24)
  └─┬repository-rule
    ├─┬ONEOF
    │ └──[🔀] $ref (74672:9)❌ 
    ├─┬ONEOF
    │ └──[🔀] $ref (74721:9)❌ 
    ├─┬ONEOF
    │ └──[🔀] $ref (74093:14)❌ 
    ├─┬ONEOF
    │ └──[🔀] $ref (74375:14)❌ 
    ├─┬ONEOF
    │ └──[🔀] $ref (74604:14)❌ 
    ├─┬ONEOF
    │ └──[🔀] $ref (74409:14)❌ 
    ├─┬ONEOF
    │ └──[🔀] $ref (74206:14)❌ 
    ├─┬ONEOF
    │ └──[🔀] $ref (74123:14)❌ 
    ├─┬ONEOF
    │ └──[🔀] $ref (74544:14)❌ 
    ├─┬ONEOF
    │ └──[🔀] $ref (74134:14)❌ 
    ├─┬ONEOF
    │ └──[🔀] $ref (74696:9)❌ 
    ├─┬ONEOF
    │ └──[🔀] $ref (74229:14)❌ 
    ├─┬ONEOF
    │ └──[🔀] $ref (74240:14)❌ 
    ├─┬ONEOF
    │ └──[🔀] $ref (74112:14)❌ 
    ├─┬ONEOF
    │ └──[🔀] $ref (74297:14)❌ 
    ├─┬ONEOF
    │ └──[🔀] $ref (74330:14)❌ 
    ├─┬ONEOF
    │ └──[🔀] $ref (74443:14)❌ 
    ├─┬ONEOF
    │ └──[🔀] $ref (74082:14)❌ 
    ├─┬ONEOF
    │ └──[🔀] $ref (74341:14)❌ 
    └─┬ONEOF
      ├──[🔀] title (74647:16)
      ├──[🔀] description (74648:22)
      ├─┬parameters
      │ ├──[➕] required (74671:15)❌ 
      │ ├──[➖] required (74673:15)❌ 
      │ ├──[➕] properties (74664:15)
      │ └──[➖] properties (74667:15)❌ 
      └─┬type
        ├──[➕] enum (74660:15)
        └──[➖] enum (74663:15)❌ 

```

| Document Element | Total Changes | Breaking Changes |
|------------------|---------------|------------------|
| paths            | 4             | 0                |
| components       | 28            | 23               |

Date: 09/11/24 | Commit: New: etc/specs/GitHub/previous.spec.yaml, Original: etc/specs/GitHub/current.spec.yaml

- ❌ **BREAKING Changes**: _23_ out of _32_
- **Modifications**: _26_
- **Removals**: _3_
- **Additions**: _3_
- **Breaking Removals**: _3_
- **Breaking Modifications**: _19_
- **Breaking Additions**: _1_

ERROR: breaking changes discovered
