### PR TITLE
[GitHubEnterpriseCloud] Update to 1.1.4-6fc53ca80578d52ccc88d457f5870461 from 1.1.4-09839999823ef90b1da82eac02b00b4b

### DIFF
--- a/clients/GitHubEnterpriseCloud/etc/openapi-client-generator.state
+++ b/clients/GitHubEnterpriseCloud/etc/openapi-client-generator.state
@@ -1,5 +1,5 @@
 {
-    "specHash": "09839999823ef90b1da82eac02b00b4b",
+    "specHash": "6fc53ca80578d52ccc88d457f5870461",
     "generatedFiles": {
         "files": [
             {
@@ -712,11 +712,11 @@
             },
             {
                 "name": ".\/clients\/GitHubEnterpriseCloud\/etc\/..\/\/src\/\/Schema\/RepositoryRule.php",
-                "hash": "420328d80162e6f58d8b9e477e1bc64b"
+                "hash": "5fa4ed003673319c9355b0ff6bad0d73"
             },
             {
                 "name": ".\/clients\/GitHubEnterpriseCloud\/etc\/..\/\/src\/\/Schema\/RepositoryRuleset.php",
-                "hash": "ad16883d58672461f2c234371bcbffb3"
+                "hash": "f73ec1eba3cba0f5a6dd3d287e1f3b9c"
             },
             {
                 "name": ".\/clients\/GitHubEnterpriseCloud\/etc\/..\/\/src\/\/Schema\/GroupMapping.php",
@@ -4928,11 +4928,11 @@
             },
             {
                 "name": ".\/clients\/GitHubEnterpriseCloud\/etc\/..\/\/src\/\/Schema\/Repos\/CreateOrgRuleset\/Request\/ApplicationJson.php",
-                "hash": "72d215a78ad1500e0524cf9996ca7c9a"
+                "hash": "6ce0f5980b25b5e0b6eef72ce49ad35f"
             },
             {
                 "name": ".\/clients\/GitHubEnterpriseCloud\/etc\/..\/\/src\/\/Schema\/Repos\/UpdateOrgRuleset\/Request\/ApplicationJson.php",
-                "hash": "027a98f8cfc8813638489bf25f06dd12"
+                "hash": "91b3f78a0a1a55299971f8d8c9bde8fd"
             },
             {
                 "name": ".\/clients\/GitHubEnterpriseCloud\/etc\/..\/\/src\/\/Schema\/Teams\/Create\/Request\/ApplicationJson.php",
@@ -5648,11 +5648,11 @@
             },
             {
                 "name": ".\/clients\/GitHubEnterpriseCloud\/etc\/..\/\/src\/\/Schema\/Repos\/CreateRepoRuleset\/Request\/ApplicationJson.php",
-                "hash": "ae12a630c4182e91688f3f4ffce367b0"
+                "hash": "42c0debe628a033b4a77dba59415e51a"
             },
             {
                 "name": ".\/clients\/GitHubEnterpriseCloud\/etc\/..\/\/src\/\/Schema\/Repos\/UpdateRepoRuleset\/Request\/ApplicationJson.php",
-                "hash": "1458f402025184131549dd43bd66d97a"
+                "hash": "cf9686db0898010dc431ed85b2d2c4f0"
             },
             {
                 "name": ".\/clients\/GitHubEnterpriseCloud\/etc\/..\/\/src\/\/Schema\/SecretScanning\/UpdateAlert\/Request\/ApplicationJson.php",
@@ -12272,15 +12272,15 @@
             },
             {
                 "name": ".\/clients\/GitHubEnterpriseCloud\/etc\/..\/\/src\/\/Schema\/WebhookRepositoryRulesetCreated.php",
-                "hash": "3c6000a4e4943a4a58ec7fd70179a902"
+                "hash": "a9f640c730494728b766cf3aa408f82a"
             },
             {
                 "name": ".\/clients\/GitHubEnterpriseCloud\/etc\/..\/\/src\/\/Schema\/WebhookRepositoryRulesetDeleted.php",
-                "hash": "9e7a45a4dd1eb89a4a4c36c016aba8e0"
+                "hash": "f3b82bb3b954a8899c6f3f314de87186"
             },
             {
                 "name": ".\/clients\/GitHubEnterpriseCloud\/etc\/..\/\/src\/\/Schema\/WebhookRepositoryRulesetEdited.php",
-                "hash": "2e62ac9bf854490f9652d92ccf97fda7"
+                "hash": "636d849d96d0047c1cc79fcc0ed7666f"
             },
             {
                 "name": ".\/clients\/GitHubEnterpriseCloud\/etc\/..\/\/src\/\/Schema\/Operations\/SecurityAdvisories\/CreateRepositoryAdvisoryCveRequest\/Response\/ApplicationJson\/Accepted.php",
@@ -12516,7 +12516,7 @@
             },
             {
                 "name": ".\/clients\/GitHubEnterpriseCloud\/etc\/..\/\/src\/\/Schema\/WebhookRepositoryRulesetEdited\/Changes.php",
-                "hash": "1b759c3d309bf8fa3f74f3205faf65a2"
+                "hash": "6d421cf63fa09ce31c45d7c372ca7b9a"
             },
             {
                 "name": ".\/clients\/GitHubEnterpriseCloud\/etc\/..\/\/src\/\/Schema\/WebhookRepositoryRulesetEdited\/Changes\/Conditions.php",
@@ -12544,11 +12544,11 @@
             },
             {
                 "name": ".\/clients\/GitHubEnterpriseCloud\/etc\/..\/\/src\/\/Schema\/WebhookRepositoryRulesetEdited\/Changes\/Rules.php",
-                "hash": "c79220e281bcef4a149c11bf98a145b4"
+                "hash": "7f2dd6c90694ac68c4b6dc0ffa2bd62c"
             },
             {
                 "name": ".\/clients\/GitHubEnterpriseCloud\/etc\/..\/\/src\/\/Schema\/WebhookRepositoryRulesetEdited\/Changes\/Rules\/Updated.php",
-                "hash": "b0cbcc4cf6ea7ddc0f4daa8f7fd4619e"
+                "hash": "b566c38eb98748330594e07ff1df237a"
             },
             {
                 "name": ".\/clients\/GitHubEnterpriseCloud\/etc\/..\/\/src\/\/Schema\/WebhookRepositoryRulesetEdited\/Changes\/Rules\/Updated\/Changes.php",
@@ -31340,7 +31340,7 @@
             },
             {
                 "name": ".\/clients\/GitHubEnterpriseCloud\/etc\/..\/\/src\/\/Schema\/RepositoryRuleset\/Rules\/Fifteen.php",
-                "hash": "114c308e3f2a63950d9682ac8e8a2272"
+                "hash": "193be77dacf5ab5836c17ad9446dc1c0"
             },
             {
                 "name": ".\/clients\/GitHubEnterpriseCloud\/etc\/..\/\/src\/\/Schema\/RepositoryRuleset\/Rules\/Fifteen\/Parameters.php",
@@ -31348,7 +31348,7 @@
             },
             {
                 "name": ".\/clients\/GitHubEnterpriseCloud\/etc\/..\/\/src\/\/Schema\/RepositoryRuleset\/Rules\/Sixteen.php",
-                "hash": "b5d13181dafa6f6a4750780d927d7e80"
+                "hash": "ee417dfdff2a48164de8980c9e159925"
             },
             {
                 "name": ".\/clients\/GitHubEnterpriseCloud\/etc\/..\/\/src\/\/Schema\/RepositoryRuleset\/Rules\/Sixteen\/Parameters.php",
@@ -31356,7 +31356,7 @@
             },
             {
                 "name": ".\/clients\/GitHubEnterpriseCloud\/etc\/..\/\/src\/\/Schema\/RepositoryRuleset\/Rules\/Seventeen.php",
-                "hash": "5910364f87a234f9d822f44b77bbde35"
+                "hash": "d43076abe21d50dfdb3a8523eb97c189"
             },
             {
                 "name": ".\/clients\/GitHubEnterpriseCloud\/etc\/..\/\/src\/\/Schema\/RepositoryRuleset\/Rules\/Seventeen\/Parameters.php",
@@ -32596,7 +32596,7 @@
             },
             {
                 "name": ".\/clients\/GitHubEnterpriseCloud\/etc\/..\/\/src\/\/Schema\/RepositoryRuleset\/Rules\/Eighteen.php",
-                "hash": "7d3bb81a45576d9d5aa1cbe1093697f3"
+                "hash": "70d3ee238689a09bec668aa5b9ce8ce0"
             },
             {
                 "name": ".\/clients\/GitHubEnterpriseCloud\/etc\/..\/\/src\/\/Schema\/RepositoryRuleset\/Rules\/Eighteen\/Parameters.php",

--- a/clients/GitHubEnterpriseCloud/src/Schema/Repos/CreateOrgRuleset/Request/ApplicationJson.php
+++ b/clients/GitHubEnterpriseCloud/src/Schema/Repos/CreateOrgRuleset/Request/ApplicationJson.php
@@ -28,7 +28,7 @@ final readonly class ApplicationJson
                 "push"
             ],
             "type": "string",
-            "description": "The target of the ruleset\\n\\n> [!NOTE]\\n> The `push` target is in beta and is subject to change.",
+            "description": "The target of the ruleset",
             "default": "branch"
         },
         "enforcement": {
@@ -916,7 +916,7 @@ final readonly class ApplicationJson
                                 }
                             }
                         },
-                        "description": "> [!NOTE]\\n> `file_path_restriction` is in beta and subject to change.\\n\\nPrevent commits that include changes in specified file paths from being pushed to the commit graph."
+                        "description": "Prevent commits that include changes in specified file paths from being pushed to the commit graph."
                     },
                     {
                         "title": "max_file_path_length",
@@ -946,7 +946,7 @@ final readonly class ApplicationJson
                                 }
                             }
                         },
-                        "description": "> [!NOTE]\\n> `max_file_path_length` is in beta and subject to change.\\n\\nPrevent commits that include file paths that exceed a specified character limit from being pushed to the commit graph."
+                        "description": "Prevent commits that include file paths that exceed a specified character limit from being pushed to the commit graph."
                     },
                     {
                         "title": "file_extension_restriction",
@@ -977,7 +977,7 @@ final readonly class ApplicationJson
                                 }
                             }
                         },
-                        "description": "> [!NOTE]\\n> `file_extension_restriction` is in beta and subject to change.\\n\\nPrevent commits that include files with specified file extensions from being pushed to the commit graph."
+                        "description": "Prevent commits that include files with specified file extensions from being pushed to the commit graph."
                     },
                     {
                         "title": "max_file_size",
@@ -1007,7 +1007,7 @@ final readonly class ApplicationJson
                                 }
                             }
                         },
-                        "description": "> [!NOTE]\\n> `max_file_size` is in beta and subject to change.\\n\\nPrevent commits that exceed a specified file size limit from being pushed to the commit."
+                        "description": "Prevent commits that exceed a specified file size limit from being pushed to the commit."
                     },
                     {
                         "title": "workflows",
@@ -1168,9 +1168,6 @@ final readonly class ApplicationJson
     /**
      * name: The name of the ruleset.
      * target: The target of the ruleset
-
-    > [!NOTE]
-    > The `push` target is in beta and is subject to change.
      * enforcement: The enforcement level of the ruleset. `evaluate` allows admins to test rules before enforcing them. Admins can view insights on the Rule Insights page.
      * bypassActors: The actors that can bypass the rules in this ruleset
      * conditions: Conditions for an organization ruleset. The conditions object should contain both `repository_name` and `ref_name` properties or both `repository_id` and `ref_name` properties.

--- a/clients/GitHubEnterpriseCloud/src/Schema/Repos/CreateRepoRuleset/Request/ApplicationJson.php
+++ b/clients/GitHubEnterpriseCloud/src/Schema/Repos/CreateRepoRuleset/Request/ApplicationJson.php
@@ -27,7 +27,7 @@ final readonly class ApplicationJson
                 "push"
             ],
             "type": "string",
-            "description": "The target of the ruleset\\n\\n> [!NOTE]\\n> The `push` target is in beta and is subject to change.",
+            "description": "The target of the ruleset",
             "default": "branch"
         },
         "enforcement": {
@@ -697,7 +697,7 @@ final readonly class ApplicationJson
                                 }
                             }
                         },
-                        "description": "> [!NOTE]\\n> `file_path_restriction` is in beta and subject to change.\\n\\nPrevent commits that include changes in specified file paths from being pushed to the commit graph."
+                        "description": "Prevent commits that include changes in specified file paths from being pushed to the commit graph."
                     },
                     {
                         "title": "max_file_path_length",
@@ -727,7 +727,7 @@ final readonly class ApplicationJson
                                 }
                             }
                         },
-                        "description": "> [!NOTE]\\n> `max_file_path_length` is in beta and subject to change.\\n\\nPrevent commits that include file paths that exceed a specified character limit from being pushed to the commit graph."
+                        "description": "Prevent commits that include file paths that exceed a specified character limit from being pushed to the commit graph."
                     },
                     {
                         "title": "file_extension_restriction",
@@ -758,7 +758,7 @@ final readonly class ApplicationJson
                                 }
                             }
                         },
-                        "description": "> [!NOTE]\\n> `file_extension_restriction` is in beta and subject to change.\\n\\nPrevent commits that include files with specified file extensions from being pushed to the commit graph."
+                        "description": "Prevent commits that include files with specified file extensions from being pushed to the commit graph."
                     },
                     {
                         "title": "max_file_size",
@@ -788,7 +788,7 @@ final readonly class ApplicationJson
                                 }
                             }
                         },
-                        "description": "> [!NOTE]\\n> `max_file_size` is in beta and subject to change.\\n\\nPrevent commits that exceed a specified file size limit from being pushed to the commit."
+                        "description": "Prevent commits that exceed a specified file size limit from being pushed to the commit."
                     },
                     {
                         "title": "workflows",
@@ -960,9 +960,6 @@ final readonly class ApplicationJson
     /**
      * name: The name of the ruleset.
      * target: The target of the ruleset
-
-    > [!NOTE]
-    > The `push` target is in beta and is subject to change.
      * enforcement: The enforcement level of the ruleset. `evaluate` allows admins to test rules before enforcing them. Admins can view insights on the Rule Insights page.
      * bypassActors: The actors that can bypass the rules in this ruleset
      * conditions: Parameters for a repository ruleset ref name condition

--- a/clients/GitHubEnterpriseCloud/src/Schema/Repos/UpdateOrgRuleset/Request/ApplicationJson.php
+++ b/clients/GitHubEnterpriseCloud/src/Schema/Repos/UpdateOrgRuleset/Request/ApplicationJson.php
@@ -24,7 +24,7 @@ final readonly class ApplicationJson
                 "push"
             ],
             "type": "string",
-            "description": "The target of the ruleset\\n\\n> [!NOTE]\\n> The `push` target is in beta and is subject to change."
+            "description": "The target of the ruleset"
         },
         "enforcement": {
             "enum": [
@@ -911,7 +911,7 @@ final readonly class ApplicationJson
                                 }
                             }
                         },
-                        "description": "> [!NOTE]\\n> `file_path_restriction` is in beta and subject to change.\\n\\nPrevent commits that include changes in specified file paths from being pushed to the commit graph."
+                        "description": "Prevent commits that include changes in specified file paths from being pushed to the commit graph."
                     },
                     {
                         "title": "max_file_path_length",
@@ -941,7 +941,7 @@ final readonly class ApplicationJson
                                 }
                             }
                         },
-                        "description": "> [!NOTE]\\n> `max_file_path_length` is in beta and subject to change.\\n\\nPrevent commits that include file paths that exceed a specified character limit from being pushed to the commit graph."
+                        "description": "Prevent commits that include file paths that exceed a specified character limit from being pushed to the commit graph."
                     },
                     {
                         "title": "file_extension_restriction",
@@ -972,7 +972,7 @@ final readonly class ApplicationJson
                                 }
                             }
                         },
-                        "description": "> [!NOTE]\\n> `file_extension_restriction` is in beta and subject to change.\\n\\nPrevent commits that include files with specified file extensions from being pushed to the commit graph."
+                        "description": "Prevent commits that include files with specified file extensions from being pushed to the commit graph."
                     },
                     {
                         "title": "max_file_size",
@@ -1002,7 +1002,7 @@ final readonly class ApplicationJson
                                 }
                             }
                         },
-                        "description": "> [!NOTE]\\n> `max_file_size` is in beta and subject to change.\\n\\nPrevent commits that exceed a specified file size limit from being pushed to the commit."
+                        "description": "Prevent commits that exceed a specified file size limit from being pushed to the commit."
                     },
                     {
                         "title": "workflows",
@@ -1163,9 +1163,6 @@ final readonly class ApplicationJson
     /**
      * name: The name of the ruleset.
      * target: The target of the ruleset
-
-    > [!NOTE]
-    > The `push` target is in beta and is subject to change.
      * enforcement: The enforcement level of the ruleset. `evaluate` allows admins to test rules before enforcing them. Admins can view insights on the Rule Insights page.
      * bypassActors: The actors that can bypass the rules in this ruleset
      * conditions: Conditions for an organization ruleset. The conditions object should contain both `repository_name` and `ref_name` properties or both `repository_id` and `ref_name` properties.

--- a/clients/GitHubEnterpriseCloud/src/Schema/Repos/UpdateRepoRuleset/Request/ApplicationJson.php
+++ b/clients/GitHubEnterpriseCloud/src/Schema/Repos/UpdateRepoRuleset/Request/ApplicationJson.php
@@ -23,7 +23,7 @@ final readonly class ApplicationJson
                 "push"
             ],
             "type": "string",
-            "description": "The target of the ruleset\\n\\n> [!NOTE]\\n> The `push` target is in beta and is subject to change."
+            "description": "The target of the ruleset"
         },
         "enforcement": {
             "enum": [
@@ -692,7 +692,7 @@ final readonly class ApplicationJson
                                 }
                             }
                         },
-                        "description": "> [!NOTE]\\n> `file_path_restriction` is in beta and subject to change.\\n\\nPrevent commits that include changes in specified file paths from being pushed to the commit graph."
+                        "description": "Prevent commits that include changes in specified file paths from being pushed to the commit graph."
                     },
                     {
                         "title": "max_file_path_length",
@@ -722,7 +722,7 @@ final readonly class ApplicationJson
                                 }
                             }
                         },
-                        "description": "> [!NOTE]\\n> `max_file_path_length` is in beta and subject to change.\\n\\nPrevent commits that include file paths that exceed a specified character limit from being pushed to the commit graph."
+                        "description": "Prevent commits that include file paths that exceed a specified character limit from being pushed to the commit graph."
                     },
                     {
                         "title": "file_extension_restriction",
@@ -753,7 +753,7 @@ final readonly class ApplicationJson
                                 }
                             }
                         },
-                        "description": "> [!NOTE]\\n> `file_extension_restriction` is in beta and subject to change.\\n\\nPrevent commits that include files with specified file extensions from being pushed to the commit graph."
+                        "description": "Prevent commits that include files with specified file extensions from being pushed to the commit graph."
                     },
                     {
                         "title": "max_file_size",
@@ -783,7 +783,7 @@ final readonly class ApplicationJson
                                 }
                             }
                         },
-                        "description": "> [!NOTE]\\n> `max_file_size` is in beta and subject to change.\\n\\nPrevent commits that exceed a specified file size limit from being pushed to the commit."
+                        "description": "Prevent commits that exceed a specified file size limit from being pushed to the commit."
                     },
                     {
                         "title": "workflows",
@@ -955,9 +955,6 @@ final readonly class ApplicationJson
     /**
      * name: The name of the ruleset.
      * target: The target of the ruleset
-
-    > [!NOTE]
-    > The `push` target is in beta and is subject to change.
      * enforcement: The enforcement level of the ruleset. `evaluate` allows admins to test rules before enforcing them. Admins can view insights on the Rule Insights page.
      * bypassActors: The actors that can bypass the rules in this ruleset
      * conditions: Parameters for a repository ruleset ref name condition

--- a/clients/GitHubEnterpriseCloud/src/Schema/RepositoryRule.php
+++ b/clients/GitHubEnterpriseCloud/src/Schema/RepositoryRule.php
@@ -595,7 +595,7 @@ final readonly class RepositoryRule
                     }
                 }
             },
-            "description": "> [!NOTE]\\n> `file_path_restriction` is in beta and subject to change.\\n\\nPrevent commits that include changes in specified file paths from being pushed to the commit graph."
+            "description": "Prevent commits that include changes in specified file paths from being pushed to the commit graph."
         },
         {
             "title": "max_file_path_length",
@@ -625,7 +625,7 @@ final readonly class RepositoryRule
                     }
                 }
             },
-            "description": "> [!NOTE]\\n> `max_file_path_length` is in beta and subject to change.\\n\\nPrevent commits that include file paths that exceed a specified character limit from being pushed to the commit graph."
+            "description": "Prevent commits that include file paths that exceed a specified character limit from being pushed to the commit graph."
         },
         {
             "title": "file_extension_restriction",
@@ -656,7 +656,7 @@ final readonly class RepositoryRule
                     }
                 }
             },
-            "description": "> [!NOTE]\\n> `file_extension_restriction` is in beta and subject to change.\\n\\nPrevent commits that include files with specified file extensions from being pushed to the commit graph."
+            "description": "Prevent commits that include files with specified file extensions from being pushed to the commit graph."
         },
         {
             "title": "max_file_size",
@@ -686,7 +686,7 @@ final readonly class RepositoryRule
                     }
                 }
             },
-            "description": "> [!NOTE]\\n> `max_file_size` is in beta and subject to change.\\n\\nPrevent commits that exceed a specified file size limit from being pushed to the commit."
+            "description": "Prevent commits that exceed a specified file size limit from being pushed to the commit."
         },
         {
             "title": "workflows",

--- a/clients/GitHubEnterpriseCloud/src/Schema/RepositoryRuleset.php
+++ b/clients/GitHubEnterpriseCloud/src/Schema/RepositoryRuleset.php
@@ -35,7 +35,7 @@ final readonly class RepositoryRuleset
                 "push"
             ],
             "type": "string",
-            "description": "The target of the ruleset\\n\\n> [!NOTE]\\n> The `push` target is in beta and is subject to change."
+            "description": "The target of the ruleset"
         },
         "source_type": {
             "enum": [
@@ -1003,7 +1003,7 @@ final readonly class RepositoryRuleset
                                 }
                             }
                         },
-                        "description": "> [!NOTE]\\n> `file_path_restriction` is in beta and subject to change.\\n\\nPrevent commits that include changes in specified file paths from being pushed to the commit graph."
+                        "description": "Prevent commits that include changes in specified file paths from being pushed to the commit graph."
                     },
                     {
                         "title": "max_file_path_length",
@@ -1033,7 +1033,7 @@ final readonly class RepositoryRuleset
                                 }
                             }
                         },
-                        "description": "> [!NOTE]\\n> `max_file_path_length` is in beta and subject to change.\\n\\nPrevent commits that include file paths that exceed a specified character limit from being pushed to the commit graph."
+                        "description": "Prevent commits that include file paths that exceed a specified character limit from being pushed to the commit graph."
                     },
                     {
                         "title": "file_extension_restriction",
@@ -1064,7 +1064,7 @@ final readonly class RepositoryRuleset
                                 }
                             }
                         },
-                        "description": "> [!NOTE]\\n> `file_extension_restriction` is in beta and subject to change.\\n\\nPrevent commits that include files with specified file extensions from being pushed to the commit graph."
+                        "description": "Prevent commits that include files with specified file extensions from being pushed to the commit graph."
                     },
                     {
                         "title": "max_file_size",
@@ -1094,7 +1094,7 @@ final readonly class RepositoryRuleset
                                 }
                             }
                         },
-                        "description": "> [!NOTE]\\n> `max_file_size` is in beta and subject to change.\\n\\nPrevent commits that exceed a specified file size limit from being pushed to the commit."
+                        "description": "Prevent commits that exceed a specified file size limit from being pushed to the commit."
                     },
                     {
                         "title": "workflows",
@@ -1279,9 +1279,6 @@ final readonly class RepositoryRuleset
      * id: The ID of the ruleset
      * name: The name of the ruleset
      * target: The target of the ruleset
-
-    > [!NOTE]
-    > The `push` target is in beta and is subject to change.
      * sourceType: The type of the source of the ruleset
      * source: The name of the source
      * enforcement: The enforcement level of the ruleset. `evaluate` allows admins to test rules before enforcing them. Admins can view insights on the Rule Insights page.

--- a/clients/GitHubEnterpriseCloud/src/Schema/RepositoryRuleset/Rules/Eighteen.php
+++ b/clients/GitHubEnterpriseCloud/src/Schema/RepositoryRuleset/Rules/Eighteen.php
@@ -36,13 +36,10 @@ final readonly class Eighteen
             }
         }
     },
-    "description": "> [!NOTE]\\n> `max_file_size` is in beta and subject to change.\\n\\nPrevent commits that exceed a specified file size limit from being pushed to the commit."
+    "description": "Prevent commits that exceed a specified file size limit from being pushed to the commit."
 }';
     public const SCHEMA_TITLE        = 'max_file_size';
-    public const SCHEMA_DESCRIPTION  = '> [!NOTE]
-> `max_file_size` is in beta and subject to change.
-
-Prevent commits that exceed a specified file size limit from being pushed to the commit.';
+    public const SCHEMA_DESCRIPTION  = 'Prevent commits that exceed a specified file size limit from being pushed to the commit.';
     public const SCHEMA_EXAMPLE_DATA = '{
     "type": "max_file_size",
     "parameters": {

--- a/clients/GitHubEnterpriseCloud/src/Schema/RepositoryRuleset/Rules/Fifteen.php
+++ b/clients/GitHubEnterpriseCloud/src/Schema/RepositoryRuleset/Rules/Fifteen.php
@@ -37,13 +37,10 @@ final readonly class Fifteen
             }
         }
     },
-    "description": "> [!NOTE]\\n> `file_path_restriction` is in beta and subject to change.\\n\\nPrevent commits that include changes in specified file paths from being pushed to the commit graph."
+    "description": "Prevent commits that include changes in specified file paths from being pushed to the commit graph."
 }';
     public const SCHEMA_TITLE        = 'file_path_restriction';
-    public const SCHEMA_DESCRIPTION  = '> [!NOTE]
-> `file_path_restriction` is in beta and subject to change.
-
-Prevent commits that include changes in specified file paths from being pushed to the commit graph.';
+    public const SCHEMA_DESCRIPTION  = 'Prevent commits that include changes in specified file paths from being pushed to the commit graph.';
     public const SCHEMA_EXAMPLE_DATA = '{
     "type": "file_path_restriction",
     "parameters": {

--- a/clients/GitHubEnterpriseCloud/src/Schema/RepositoryRuleset/Rules/Seventeen.php
+++ b/clients/GitHubEnterpriseCloud/src/Schema/RepositoryRuleset/Rules/Seventeen.php
@@ -37,13 +37,10 @@ final readonly class Seventeen
             }
         }
     },
-    "description": "> [!NOTE]\\n> `file_extension_restriction` is in beta and subject to change.\\n\\nPrevent commits that include files with specified file extensions from being pushed to the commit graph."
+    "description": "Prevent commits that include files with specified file extensions from being pushed to the commit graph."
 }';
     public const SCHEMA_TITLE        = 'file_extension_restriction';
-    public const SCHEMA_DESCRIPTION  = '> [!NOTE]
-> `file_extension_restriction` is in beta and subject to change.
-
-Prevent commits that include files with specified file extensions from being pushed to the commit graph.';
+    public const SCHEMA_DESCRIPTION  = 'Prevent commits that include files with specified file extensions from being pushed to the commit graph.';
     public const SCHEMA_EXAMPLE_DATA = '{
     "type": "file_extension_restriction",
     "parameters": {

--- a/clients/GitHubEnterpriseCloud/src/Schema/RepositoryRuleset/Rules/Sixteen.php
+++ b/clients/GitHubEnterpriseCloud/src/Schema/RepositoryRuleset/Rules/Sixteen.php
@@ -36,13 +36,10 @@ final readonly class Sixteen
             }
         }
     },
-    "description": "> [!NOTE]\\n> `max_file_path_length` is in beta and subject to change.\\n\\nPrevent commits that include file paths that exceed a specified character limit from being pushed to the commit graph."
+    "description": "Prevent commits that include file paths that exceed a specified character limit from being pushed to the commit graph."
 }';
     public const SCHEMA_TITLE        = 'max_file_path_length';
-    public const SCHEMA_DESCRIPTION  = '> [!NOTE]
-> `max_file_path_length` is in beta and subject to change.
-
-Prevent commits that include file paths that exceed a specified character limit from being pushed to the commit graph.';
+    public const SCHEMA_DESCRIPTION  = 'Prevent commits that include file paths that exceed a specified character limit from being pushed to the commit graph.';
     public const SCHEMA_EXAMPLE_DATA = '{
     "type": "max_file_path_length",
     "parameters": {

--- a/clients/GitHubEnterpriseCloud/src/Schema/WebhookRepositoryRulesetCreated.php
+++ b/clients/GitHubEnterpriseCloud/src/Schema/WebhookRepositoryRulesetCreated.php
@@ -1740,7 +1740,7 @@ final readonly class WebhookRepositoryRulesetCreated
                         "push"
                     ],
                     "type": "string",
-                    "description": "The target of the ruleset\\n\\n> [!NOTE]\\n> The `push` target is in beta and is subject to change."
+                    "description": "The target of the ruleset"
                 },
                 "source_type": {
                     "enum": [
@@ -2708,7 +2708,7 @@ final readonly class WebhookRepositoryRulesetCreated
                                         }
                                     }
                                 },
-                                "description": "> [!NOTE]\\n> `file_path_restriction` is in beta and subject to change.\\n\\nPrevent commits that include changes in specified file paths from being pushed to the commit graph."
+                                "description": "Prevent commits that include changes in specified file paths from being pushed to the commit graph."
                             },
                             {
                                 "title": "max_file_path_length",
@@ -2738,7 +2738,7 @@ final readonly class WebhookRepositoryRulesetCreated
                                         }
                                     }
                                 },
-                                "description": "> [!NOTE]\\n> `max_file_path_length` is in beta and subject to change.\\n\\nPrevent commits that include file paths that exceed a specified character limit from being pushed to the commit graph."
+                                "description": "Prevent commits that include file paths that exceed a specified character limit from being pushed to the commit graph."
                             },
                             {
                                 "title": "file_extension_restriction",
@@ -2769,7 +2769,7 @@ final readonly class WebhookRepositoryRulesetCreated
                                         }
                                     }
                                 },
-                                "description": "> [!NOTE]\\n> `file_extension_restriction` is in beta and subject to change.\\n\\nPrevent commits that include files with specified file extensions from being pushed to the commit graph."
+                                "description": "Prevent commits that include files with specified file extensions from being pushed to the commit graph."
                             },
                             {
                                 "title": "max_file_size",
@@ -2799,7 +2799,7 @@ final readonly class WebhookRepositoryRulesetCreated
                                         }
                                     }
                                 },
-                                "description": "> [!NOTE]\\n> `max_file_size` is in beta and subject to change.\\n\\nPrevent commits that exceed a specified file size limit from being pushed to the commit."
+                                "description": "Prevent commits that exceed a specified file size limit from being pushed to the commit."
                             },
                             {
                                 "title": "workflows",

--- a/clients/GitHubEnterpriseCloud/src/Schema/WebhookRepositoryRulesetDeleted.php
+++ b/clients/GitHubEnterpriseCloud/src/Schema/WebhookRepositoryRulesetDeleted.php
@@ -1740,7 +1740,7 @@ final readonly class WebhookRepositoryRulesetDeleted
                         "push"
                     ],
                     "type": "string",
-                    "description": "The target of the ruleset\\n\\n> [!NOTE]\\n> The `push` target is in beta and is subject to change."
+                    "description": "The target of the ruleset"
                 },
                 "source_type": {
                     "enum": [
@@ -2708,7 +2708,7 @@ final readonly class WebhookRepositoryRulesetDeleted
                                         }
                                     }
                                 },
-                                "description": "> [!NOTE]\\n> `file_path_restriction` is in beta and subject to change.\\n\\nPrevent commits that include changes in specified file paths from being pushed to the commit graph."
+                                "description": "Prevent commits that include changes in specified file paths from being pushed to the commit graph."
                             },
                             {
                                 "title": "max_file_path_length",
@@ -2738,7 +2738,7 @@ final readonly class WebhookRepositoryRulesetDeleted
                                         }
                                     }
                                 },
-                                "description": "> [!NOTE]\\n> `max_file_path_length` is in beta and subject to change.\\n\\nPrevent commits that include file paths that exceed a specified character limit from being pushed to the commit graph."
+                                "description": "Prevent commits that include file paths that exceed a specified character limit from being pushed to the commit graph."
                             },
                             {
                                 "title": "file_extension_restriction",
@@ -2769,7 +2769,7 @@ final readonly class WebhookRepositoryRulesetDeleted
                                         }
                                     }
                                 },
-                                "description": "> [!NOTE]\\n> `file_extension_restriction` is in beta and subject to change.\\n\\nPrevent commits that include files with specified file extensions from being pushed to the commit graph."
+                                "description": "Prevent commits that include files with specified file extensions from being pushed to the commit graph."
                             },
                             {
                                 "title": "max_file_size",
@@ -2799,7 +2799,7 @@ final readonly class WebhookRepositoryRulesetDeleted
                                         }
                                     }
                                 },
-                                "description": "> [!NOTE]\\n> `max_file_size` is in beta and subject to change.\\n\\nPrevent commits that exceed a specified file size limit from being pushed to the commit."
+                                "description": "Prevent commits that exceed a specified file size limit from being pushed to the commit."
                             },
                             {
                                 "title": "workflows",

--- a/clients/GitHubEnterpriseCloud/src/Schema/WebhookRepositoryRulesetEdited.php
+++ b/clients/GitHubEnterpriseCloud/src/Schema/WebhookRepositoryRulesetEdited.php
@@ -1740,7 +1740,7 @@ final readonly class WebhookRepositoryRulesetEdited
                         "push"
                     ],
                     "type": "string",
-                    "description": "The target of the ruleset\\n\\n> [!NOTE]\\n> The `push` target is in beta and is subject to change."
+                    "description": "The target of the ruleset"
                 },
                 "source_type": {
                     "enum": [
@@ -2708,7 +2708,7 @@ final readonly class WebhookRepositoryRulesetEdited
                                         }
                                     }
                                 },
-                                "description": "> [!NOTE]\\n> `file_path_restriction` is in beta and subject to change.\\n\\nPrevent commits that include changes in specified file paths from being pushed to the commit graph."
+                                "description": "Prevent commits that include changes in specified file paths from being pushed to the commit graph."
                             },
                             {
                                 "title": "max_file_path_length",
@@ -2738,7 +2738,7 @@ final readonly class WebhookRepositoryRulesetEdited
                                         }
                                     }
                                 },
-                                "description": "> [!NOTE]\\n> `max_file_path_length` is in beta and subject to change.\\n\\nPrevent commits that include file paths that exceed a specified character limit from being pushed to the commit graph."
+                                "description": "Prevent commits that include file paths that exceed a specified character limit from being pushed to the commit graph."
                             },
                             {
                                 "title": "file_extension_restriction",
@@ -2769,7 +2769,7 @@ final readonly class WebhookRepositoryRulesetEdited
                                         }
                                     }
                                 },
-                                "description": "> [!NOTE]\\n> `file_extension_restriction` is in beta and subject to change.\\n\\nPrevent commits that include files with specified file extensions from being pushed to the commit graph."
+                                "description": "Prevent commits that include files with specified file extensions from being pushed to the commit graph."
                             },
                             {
                                 "title": "max_file_size",
@@ -2799,7 +2799,7 @@ final readonly class WebhookRepositoryRulesetEdited
                                         }
                                     }
                                 },
-                                "description": "> [!NOTE]\\n> `max_file_size` is in beta and subject to change.\\n\\nPrevent commits that exceed a specified file size limit from being pushed to the commit."
+                                "description": "Prevent commits that exceed a specified file size limit from being pushed to the commit."
                             },
                             {
                                 "title": "workflows",
@@ -3693,7 +3693,7 @@ final readonly class WebhookRepositoryRulesetEdited
                                                 }
                                             }
                                         },
-                                        "description": "> [!NOTE]\\n> `file_path_restriction` is in beta and subject to change.\\n\\nPrevent commits that include changes in specified file paths from being pushed to the commit graph."
+                                        "description": "Prevent commits that include changes in specified file paths from being pushed to the commit graph."
                                     },
                                     {
                                         "title": "max_file_path_length",
@@ -3723,7 +3723,7 @@ final readonly class WebhookRepositoryRulesetEdited
                                                 }
                                             }
                                         },
-                                        "description": "> [!NOTE]\\n> `max_file_path_length` is in beta and subject to change.\\n\\nPrevent commits that include file paths that exceed a specified character limit from being pushed to the commit graph."
+                                        "description": "Prevent commits that include file paths that exceed a specified character limit from being pushed to the commit graph."
                                     },
                                     {
                                         "title": "file_extension_restriction",
@@ -3754,7 +3754,7 @@ final readonly class WebhookRepositoryRulesetEdited
                                                 }
                                             }
                                         },
-                                        "description": "> [!NOTE]\\n> `file_extension_restriction` is in beta and subject to change.\\n\\nPrevent commits that include files with specified file extensions from being pushed to the commit graph."
+                                        "description": "Prevent commits that include files with specified file extensions from being pushed to the commit graph."
                                     },
                                     {
                                         "title": "max_file_size",
@@ -3784,7 +3784,7 @@ final readonly class WebhookRepositoryRulesetEdited
                                                 }
                                             }
                                         },
-                                        "description": "> [!NOTE]\\n> `max_file_size` is in beta and subject to change.\\n\\nPrevent commits that exceed a specified file size limit from being pushed to the commit."
+                                        "description": "Prevent commits that exceed a specified file size limit from being pushed to the commit."
                                     },
                                     {
                                         "title": "workflows",
@@ -4505,7 +4505,7 @@ final readonly class WebhookRepositoryRulesetEdited
                                                 }
                                             }
                                         },
-                                        "description": "> [!NOTE]\\n> `file_path_restriction` is in beta and subject to change.\\n\\nPrevent commits that include changes in specified file paths from being pushed to the commit graph."
+                                        "description": "Prevent commits that include changes in specified file paths from being pushed to the commit graph."
                                     },
                                     {
                                         "title": "max_file_path_length",
@@ -4535,7 +4535,7 @@ final readonly class WebhookRepositoryRulesetEdited
                                                 }
                                             }
                                         },
-                                        "description": "> [!NOTE]\\n> `max_file_path_length` is in beta and subject to change.\\n\\nPrevent commits that include file paths that exceed a specified character limit from being pushed to the commit graph."
+                                        "description": "Prevent commits that include file paths that exceed a specified character limit from being pushed to the commit graph."
                                     },
                                     {
                                         "title": "file_extension_restriction",
@@ -4566,7 +4566,7 @@ final readonly class WebhookRepositoryRulesetEdited
                                                 }
                                             }
                                         },
-                                        "description": "> [!NOTE]\\n> `file_extension_restriction` is in beta and subject to change.\\n\\nPrevent commits that include files with specified file extensions from being pushed to the commit graph."
+                                        "description": "Prevent commits that include files with specified file extensions from being pushed to the commit graph."
                                     },
                                     {
                                         "title": "max_file_size",
@@ -4596,7 +4596,7 @@ final readonly class WebhookRepositoryRulesetEdited
                                                 }
                                             }
                                         },
-                                        "description": "> [!NOTE]\\n> `max_file_size` is in beta and subject to change.\\n\\nPrevent commits that exceed a specified file size limit from being pushed to the commit."
+                                        "description": "Prevent commits that exceed a specified file size limit from being pushed to the commit."
                                     },
                                     {
                                         "title": "workflows",
@@ -5320,7 +5320,7 @@ final readonly class WebhookRepositoryRulesetEdited
                                                         }
                                                     }
                                                 },
-                                                "description": "> [!NOTE]\\n> `file_path_restriction` is in beta and subject to change.\\n\\nPrevent commits that include changes in specified file paths from being pushed to the commit graph."
+                                                "description": "Prevent commits that include changes in specified file paths from being pushed to the commit graph."
                                             },
                                             {
                                                 "title": "max_file_path_length",
@@ -5350,7 +5350,7 @@ final readonly class WebhookRepositoryRulesetEdited
                                                         }
                                                     }
                                                 },
-                                                "description": "> [!NOTE]\\n> `max_file_path_length` is in beta and subject to change.\\n\\nPrevent commits that include file paths that exceed a specified character limit from being pushed to the commit graph."
+                                                "description": "Prevent commits that include file paths that exceed a specified character limit from being pushed to the commit graph."
                                             },
                                             {
                                                 "title": "file_extension_restriction",
@@ -5381,7 +5381,7 @@ final readonly class WebhookRepositoryRulesetEdited
                                                         }
                                                     }
                                                 },
-                                                "description": "> [!NOTE]\\n> `file_extension_restriction` is in beta and subject to change.\\n\\nPrevent commits that include files with specified file extensions from being pushed to the commit graph."
+                                                "description": "Prevent commits that include files with specified file extensions from being pushed to the commit graph."
                                             },
                                             {
                                                 "title": "max_file_size",
@@ -5411,7 +5411,7 @@ final readonly class WebhookRepositoryRulesetEdited
                                                         }
                                                     }
                                                 },
-                                                "description": "> [!NOTE]\\n> `max_file_size` is in beta and subject to change.\\n\\nPrevent commits that exceed a specified file size limit from being pushed to the commit."
+                                                "description": "Prevent commits that exceed a specified file size limit from being pushed to the commit."
                                             },
                                             {
                                                 "title": "workflows",

--- a/clients/GitHubEnterpriseCloud/src/Schema/WebhookRepositoryRulesetEdited/Changes.php
+++ b/clients/GitHubEnterpriseCloud/src/Schema/WebhookRepositoryRulesetEdited/Changes.php
@@ -761,7 +761,7 @@ final readonly class Changes
                                         }
                                     }
                                 },
-                                "description": "> [!NOTE]\\n> `file_path_restriction` is in beta and subject to change.\\n\\nPrevent commits that include changes in specified file paths from being pushed to the commit graph."
+                                "description": "Prevent commits that include changes in specified file paths from being pushed to the commit graph."
                             },
                             {
                                 "title": "max_file_path_length",
@@ -791,7 +791,7 @@ final readonly class Changes
                                         }
                                     }
                                 },
-                                "description": "> [!NOTE]\\n> `max_file_path_length` is in beta and subject to change.\\n\\nPrevent commits that include file paths that exceed a specified character limit from being pushed to the commit graph."
+                                "description": "Prevent commits that include file paths that exceed a specified character limit from being pushed to the commit graph."
                             },
                             {
                                 "title": "file_extension_restriction",
@@ -822,7 +822,7 @@ final readonly class Changes
                                         }
                                     }
                                 },
-                                "description": "> [!NOTE]\\n> `file_extension_restriction` is in beta and subject to change.\\n\\nPrevent commits that include files with specified file extensions from being pushed to the commit graph."
+                                "description": "Prevent commits that include files with specified file extensions from being pushed to the commit graph."
                             },
                             {
                                 "title": "max_file_size",
@@ -852,7 +852,7 @@ final readonly class Changes
                                         }
                                     }
                                 },
-                                "description": "> [!NOTE]\\n> `max_file_size` is in beta and subject to change.\\n\\nPrevent commits that exceed a specified file size limit from being pushed to the commit."
+                                "description": "Prevent commits that exceed a specified file size limit from being pushed to the commit."
                             },
                             {
                                 "title": "workflows",
@@ -1573,7 +1573,7 @@ final readonly class Changes
                                         }
                                     }
                                 },
-                                "description": "> [!NOTE]\\n> `file_path_restriction` is in beta and subject to change.\\n\\nPrevent commits that include changes in specified file paths from being pushed to the commit graph."
+                                "description": "Prevent commits that include changes in specified file paths from being pushed to the commit graph."
                             },
                             {
                                 "title": "max_file_path_length",
@@ -1603,7 +1603,7 @@ final readonly class Changes
                                         }
                                     }
                                 },
-                                "description": "> [!NOTE]\\n> `max_file_path_length` is in beta and subject to change.\\n\\nPrevent commits that include file paths that exceed a specified character limit from being pushed to the commit graph."
+                                "description": "Prevent commits that include file paths that exceed a specified character limit from being pushed to the commit graph."
                             },
                             {
                                 "title": "file_extension_restriction",
@@ -1634,7 +1634,7 @@ final readonly class Changes
                                         }
                                     }
                                 },
-                                "description": "> [!NOTE]\\n> `file_extension_restriction` is in beta and subject to change.\\n\\nPrevent commits that include files with specified file extensions from being pushed to the commit graph."
+                                "description": "Prevent commits that include files with specified file extensions from being pushed to the commit graph."
                             },
                             {
                                 "title": "max_file_size",
@@ -1664,7 +1664,7 @@ final readonly class Changes
                                         }
                                     }
                                 },
-                                "description": "> [!NOTE]\\n> `max_file_size` is in beta and subject to change.\\n\\nPrevent commits that exceed a specified file size limit from being pushed to the commit."
+                                "description": "Prevent commits that exceed a specified file size limit from being pushed to the commit."
                             },
                             {
                                 "title": "workflows",
@@ -2388,7 +2388,7 @@ final readonly class Changes
                                                 }
                                             }
                                         },
-                                        "description": "> [!NOTE]\\n> `file_path_restriction` is in beta and subject to change.\\n\\nPrevent commits that include changes in specified file paths from being pushed to the commit graph."
+                                        "description": "Prevent commits that include changes in specified file paths from being pushed to the commit graph."
                                     },
                                     {
                                         "title": "max_file_path_length",
@@ -2418,7 +2418,7 @@ final readonly class Changes
                                                 }
                                             }
                                         },
-                                        "description": "> [!NOTE]\\n> `max_file_path_length` is in beta and subject to change.\\n\\nPrevent commits that include file paths that exceed a specified character limit from being pushed to the commit graph."
+                                        "description": "Prevent commits that include file paths that exceed a specified character limit from being pushed to the commit graph."
                                     },
                                     {
                                         "title": "file_extension_restriction",
@@ -2449,7 +2449,7 @@ final readonly class Changes
                                                 }
                                             }
                                         },
-                                        "description": "> [!NOTE]\\n> `file_extension_restriction` is in beta and subject to change.\\n\\nPrevent commits that include files with specified file extensions from being pushed to the commit graph."
+                                        "description": "Prevent commits that include files with specified file extensions from being pushed to the commit graph."
                                     },
                                     {
                                         "title": "max_file_size",
@@ -2479,7 +2479,7 @@ final readonly class Changes
                                                 }
                                             }
                                         },
-                                        "description": "> [!NOTE]\\n> `max_file_size` is in beta and subject to change.\\n\\nPrevent commits that exceed a specified file size limit from being pushed to the commit."
+                                        "description": "Prevent commits that exceed a specified file size limit from being pushed to the commit."
                                     },
                                     {
                                         "title": "workflows",

--- a/clients/GitHubEnterpriseCloud/src/Schema/WebhookRepositoryRulesetEdited/Changes/Rules.php
+++ b/clients/GitHubEnterpriseCloud/src/Schema/WebhookRepositoryRulesetEdited/Changes/Rules.php
@@ -600,7 +600,7 @@ final readonly class Rules
                                 }
                             }
                         },
-                        "description": "> [!NOTE]\\n> `file_path_restriction` is in beta and subject to change.\\n\\nPrevent commits that include changes in specified file paths from being pushed to the commit graph."
+                        "description": "Prevent commits that include changes in specified file paths from being pushed to the commit graph."
                     },
                     {
                         "title": "max_file_path_length",
@@ -630,7 +630,7 @@ final readonly class Rules
                                 }
                             }
                         },
-                        "description": "> [!NOTE]\\n> `max_file_path_length` is in beta and subject to change.\\n\\nPrevent commits that include file paths that exceed a specified character limit from being pushed to the commit graph."
+                        "description": "Prevent commits that include file paths that exceed a specified character limit from being pushed to the commit graph."
                     },
                     {
                         "title": "file_extension_restriction",
@@ -661,7 +661,7 @@ final readonly class Rules
                                 }
                             }
                         },
-                        "description": "> [!NOTE]\\n> `file_extension_restriction` is in beta and subject to change.\\n\\nPrevent commits that include files with specified file extensions from being pushed to the commit graph."
+                        "description": "Prevent commits that include files with specified file extensions from being pushed to the commit graph."
                     },
                     {
                         "title": "max_file_size",
@@ -691,7 +691,7 @@ final readonly class Rules
                                 }
                             }
                         },
-                        "description": "> [!NOTE]\\n> `max_file_size` is in beta and subject to change.\\n\\nPrevent commits that exceed a specified file size limit from being pushed to the commit."
+                        "description": "Prevent commits that exceed a specified file size limit from being pushed to the commit."
                     },
                     {
                         "title": "workflows",
@@ -1412,7 +1412,7 @@ final readonly class Rules
                                 }
                             }
                         },
-                        "description": "> [!NOTE]\\n> `file_path_restriction` is in beta and subject to change.\\n\\nPrevent commits that include changes in specified file paths from being pushed to the commit graph."
+                        "description": "Prevent commits that include changes in specified file paths from being pushed to the commit graph."
                     },
                     {
                         "title": "max_file_path_length",
@@ -1442,7 +1442,7 @@ final readonly class Rules
                                 }
                             }
                         },
-                        "description": "> [!NOTE]\\n> `max_file_path_length` is in beta and subject to change.\\n\\nPrevent commits that include file paths that exceed a specified character limit from being pushed to the commit graph."
+                        "description": "Prevent commits that include file paths that exceed a specified character limit from being pushed to the commit graph."
                     },
                     {
                         "title": "file_extension_restriction",
@@ -1473,7 +1473,7 @@ final readonly class Rules
                                 }
                             }
                         },
-                        "description": "> [!NOTE]\\n> `file_extension_restriction` is in beta and subject to change.\\n\\nPrevent commits that include files with specified file extensions from being pushed to the commit graph."
+                        "description": "Prevent commits that include files with specified file extensions from being pushed to the commit graph."
                     },
                     {
                         "title": "max_file_size",
@@ -1503,7 +1503,7 @@ final readonly class Rules
                                 }
                             }
                         },
-                        "description": "> [!NOTE]\\n> `max_file_size` is in beta and subject to change.\\n\\nPrevent commits that exceed a specified file size limit from being pushed to the commit."
+                        "description": "Prevent commits that exceed a specified file size limit from being pushed to the commit."
                     },
                     {
                         "title": "workflows",
@@ -2227,7 +2227,7 @@ final readonly class Rules
                                         }
                                     }
                                 },
-                                "description": "> [!NOTE]\\n> `file_path_restriction` is in beta and subject to change.\\n\\nPrevent commits that include changes in specified file paths from being pushed to the commit graph."
+                                "description": "Prevent commits that include changes in specified file paths from being pushed to the commit graph."
                             },
                             {
                                 "title": "max_file_path_length",
@@ -2257,7 +2257,7 @@ final readonly class Rules
                                         }
                                     }
                                 },
-                                "description": "> [!NOTE]\\n> `max_file_path_length` is in beta and subject to change.\\n\\nPrevent commits that include file paths that exceed a specified character limit from being pushed to the commit graph."
+                                "description": "Prevent commits that include file paths that exceed a specified character limit from being pushed to the commit graph."
                             },
                             {
                                 "title": "file_extension_restriction",
@@ -2288,7 +2288,7 @@ final readonly class Rules
                                         }
                                     }
                                 },
-                                "description": "> [!NOTE]\\n> `file_extension_restriction` is in beta and subject to change.\\n\\nPrevent commits that include files with specified file extensions from being pushed to the commit graph."
+                                "description": "Prevent commits that include files with specified file extensions from being pushed to the commit graph."
                             },
                             {
                                 "title": "max_file_size",
@@ -2318,7 +2318,7 @@ final readonly class Rules
                                         }
                                     }
                                 },
-                                "description": "> [!NOTE]\\n> `max_file_size` is in beta and subject to change.\\n\\nPrevent commits that exceed a specified file size limit from being pushed to the commit."
+                                "description": "Prevent commits that exceed a specified file size limit from being pushed to the commit."
                             },
                             {
                                 "title": "workflows",

--- a/clients/GitHubEnterpriseCloud/src/Schema/WebhookRepositoryRulesetEdited/Changes/Rules/Updated.php
+++ b/clients/GitHubEnterpriseCloud/src/Schema/WebhookRepositoryRulesetEdited/Changes/Rules/Updated.php
@@ -601,7 +601,7 @@ final readonly class Updated
                             }
                         }
                     },
-                    "description": "> [!NOTE]\\n> `file_path_restriction` is in beta and subject to change.\\n\\nPrevent commits that include changes in specified file paths from being pushed to the commit graph."
+                    "description": "Prevent commits that include changes in specified file paths from being pushed to the commit graph."
                 },
                 {
                     "title": "max_file_path_length",
@@ -631,7 +631,7 @@ final readonly class Updated
                             }
                         }
                     },
-                    "description": "> [!NOTE]\\n> `max_file_path_length` is in beta and subject to change.\\n\\nPrevent commits that include file paths that exceed a specified character limit from being pushed to the commit graph."
+                    "description": "Prevent commits that include file paths that exceed a specified character limit from being pushed to the commit graph."
                 },
                 {
                     "title": "file_extension_restriction",
@@ -662,7 +662,7 @@ final readonly class Updated
                             }
                         }
                     },
-                    "description": "> [!NOTE]\\n> `file_extension_restriction` is in beta and subject to change.\\n\\nPrevent commits that include files with specified file extensions from being pushed to the commit graph."
+                    "description": "Prevent commits that include files with specified file extensions from being pushed to the commit graph."
                 },
                 {
                     "title": "max_file_size",
@@ -692,7 +692,7 @@ final readonly class Updated
                             }
                         }
                     },
-                    "description": "> [!NOTE]\\n> `max_file_size` is in beta and subject to change.\\n\\nPrevent commits that exceed a specified file size limit from being pushed to the commit."
+                    "description": "Prevent commits that exceed a specified file size limit from being pushed to the commit."
                 },
                 {
                     "title": "workflows",


### PR DESCRIPTION
Detected Schema changes:
2024-09-11 17:54:46 ERROR unable to open the rolodex file, check specification references and base path
                      ├ file: /__w/github-root/github-root/server-statistics-actions.yaml
                      └ error: open /__w/github-root/github-root/server-statistics-actions.yaml: no such file or directory
2024-09-11 17:54:46 ERROR unable to open the rolodex file, check specification references and base path
                      ├ file: /__w/github-root/github-root/server-statistics-packages.yaml
                      └ error: open /__w/github-root/github-root/server-statistics-packages.yaml: no such file or directory
2024-09-11 17:54:46 ERROR unable to open the rolodex file, check specification references and base path
                      ├ file: /__w/github-root/github-root/server-statistics-advisory-db.yaml
                      └ error: open /__w/github-root/github-root/server-statistics-advisory-db.yaml: no such file or directory
2024-09-11 17:54:49 ERROR unable to open the rolodex file, check specification references and base path
                      ├ file: /__w/github-root/github-root/server-statistics-actions.yaml
                      └ error: open /__w/github-root/github-root/server-statistics-actions.yaml: no such file or directory
2024-09-11 17:54:49 ERROR unable to open the rolodex file, check specification references and base path
                      ├ file: /__w/github-root/github-root/server-statistics-packages.yaml
                      └ error: open /__w/github-root/github-root/server-statistics-packages.yaml: no such file or directory
2024-09-11 17:54:49 ERROR unable to open the rolodex file, check specification references and base path
                      ├ file: /__w/github-root/github-root/server-statistics-advisory-db.yaml
                      └ error: open /__w/github-root/github-root/server-statistics-advisory-db.yaml: no such file or directory
ERROR: component 'server-statistics-actions.yaml' does not exist in the specification
ERROR: component 'server-statistics-packages.yaml' does not exist in the specification
ERROR: component 'server-statistics-advisory-db.yaml' does not exist in the specification
ERROR: cannot resolve reference `server-statistics-actions.yaml`, it's missing:  [207907:11]
ERROR: cannot resolve reference `server-statistics-packages.yaml`, it's missing:  [207909:11]
ERROR: cannot resolve reference `server-statistics-advisory-db.yaml`, it's missing:  [207911:11]
ERROR: component 'server-statistics-actions.yaml' does not exist in the specification
ERROR: component 'server-statistics-packages.yaml' does not exist in the specification
ERROR: component 'server-statistics-advisory-db.yaml' does not exist in the specification
ERROR: cannot resolve reference `server-statistics-actions.yaml`, it's missing:  [207939:11]
ERROR: cannot resolve reference `server-statistics-packages.yaml`, it's missing:  [207941:11]
ERROR: cannot resolve reference `server-statistics-advisory-db.yaml`, it's missing:  [207943:11]
