### PR TITLE
[GitHubEnterpriseCloud] Update to 1.1.4-e44a416901524b2c0d9993b097322ff2 from 1.1.4-9490e41553676ba8db2a5129723d9e63

### DIFF
--- a/clients/GitHubEnterpriseCloud/etc/openapi-client-generator.state
+++ b/clients/GitHubEnterpriseCloud/etc/openapi-client-generator.state
@@ -1,5 +1,5 @@
 {
-    "specHash": "9490e41553676ba8db2a5129723d9e63",
+    "specHash": "e44a416901524b2c0d9993b097322ff2",
     "generatedFiles": {
         "files": [
             {


### PR DESCRIPTION
Detected Schema changes:
2024-09-26 17:30:34 ERROR unable to open the rolodex file, check specification references and base path
                      ├ file: /__w/github-root/github-root/server-statistics-actions.yaml
                      └ error: open /__w/github-root/github-root/server-statistics-actions.yaml: no such file or directory
2024-09-26 17:30:34 ERROR unable to open the rolodex file, check specification references and base path
                      ├ file: /__w/github-root/github-root/server-statistics-packages.yaml
                      └ error: open /__w/github-root/github-root/server-statistics-packages.yaml: no such file or directory
2024-09-26 17:30:34 ERROR unable to open the rolodex file, check specification references and base path
                      ├ file: /__w/github-root/github-root/server-statistics-advisory-db.yaml
                      └ error: open /__w/github-root/github-root/server-statistics-advisory-db.yaml: no such file or directory
2024-09-26 17:30:37 ERROR unable to open the rolodex file, check specification references and base path
                      ├ file: /__w/github-root/github-root/server-statistics-actions.yaml
                      └ error: open /__w/github-root/github-root/server-statistics-actions.yaml: no such file or directory
2024-09-26 17:30:37 ERROR unable to open the rolodex file, check specification references and base path
                      ├ file: /__w/github-root/github-root/server-statistics-packages.yaml
                      └ error: open /__w/github-root/github-root/server-statistics-packages.yaml: no such file or directory
2024-09-26 17:30:37 ERROR unable to open the rolodex file, check specification references and base path
                      ├ file: /__w/github-root/github-root/server-statistics-advisory-db.yaml
                      └ error: open /__w/github-root/github-root/server-statistics-advisory-db.yaml: no such file or directory
ERROR: component 'server-statistics-actions.yaml' does not exist in the specification
ERROR: component 'server-statistics-packages.yaml' does not exist in the specification
ERROR: component 'server-statistics-advisory-db.yaml' does not exist in the specification
ERROR: cannot resolve reference `server-statistics-actions.yaml`, it's missing:  [208007:11]
ERROR: cannot resolve reference `server-statistics-packages.yaml`, it's missing:  [208009:11]
ERROR: cannot resolve reference `server-statistics-advisory-db.yaml`, it's missing:  [208011:11]
ERROR: component 'server-statistics-actions.yaml' does not exist in the specification
ERROR: component 'server-statistics-packages.yaml' does not exist in the specification
ERROR: component 'server-statistics-advisory-db.yaml' does not exist in the specification
ERROR: cannot resolve reference `server-statistics-actions.yaml`, it's missing:  [208006:11]
ERROR: cannot resolve reference `server-statistics-packages.yaml`, it's missing:  [208008:11]
ERROR: cannot resolve reference `server-statistics-advisory-db.yaml`, it's missing:  [208010:11]
