### PR TITLE
[GitHubEnterpriseCloud] Update to 1.1.4-25c84342b0a57e02594127b0dd21daae from 1.1.4-197765ae314cd6366887510a47df29dc

### DIFF
--- a/clients/GitHubEnterpriseCloud/etc/openapi-client-generator.state
+++ b/clients/GitHubEnterpriseCloud/etc/openapi-client-generator.state
@@ -1,5 +1,5 @@
 {
-    "specHash": "197765ae314cd6366887510a47df29dc",
+    "specHash": "25c84342b0a57e02594127b0dd21daae",
     "generatedFiles": {
         "files": [
             {


### PR DESCRIPTION
Detected Schema changes:
2024-10-25 17:29:33 ERROR unable to open the rolodex file, check specification references and base path
                      ├ file: /__w/github-root/github-root/server-statistics-actions.yaml
                      └ error: open /__w/github-root/github-root/server-statistics-actions.yaml: no such file or directory
2024-10-25 17:29:33 ERROR unable to open the rolodex file, check specification references and base path
                      ├ file: /__w/github-root/github-root/server-statistics-packages.yaml
                      └ error: open /__w/github-root/github-root/server-statistics-packages.yaml: no such file or directory
2024-10-25 17:29:33 ERROR unable to open the rolodex file, check specification references and base path
                      ├ file: /__w/github-root/github-root/server-statistics-advisory-db.yaml
                      └ error: open /__w/github-root/github-root/server-statistics-advisory-db.yaml: no such file or directory
2024-10-25 17:29:35 ERROR unable to open the rolodex file, check specification references and base path
                      ├ file: /__w/github-root/github-root/server-statistics-actions.yaml
                      └ error: open /__w/github-root/github-root/server-statistics-actions.yaml: no such file or directory
2024-10-25 17:29:35 ERROR unable to open the rolodex file, check specification references and base path
                      ├ error: open /__w/github-root/github-root/server-statistics-packages.yaml: no such file or directory
                      └ file: /__w/github-root/github-root/server-statistics-packages.yaml
2024-10-25 17:29:35 ERROR unable to open the rolodex file, check specification references and base path
                      ├ file: /__w/github-root/github-root/server-statistics-advisory-db.yaml
                      └ error: open /__w/github-root/github-root/server-statistics-advisory-db.yaml: no such file or directory
ERROR: component `server-statistics-actions.yaml` does not exist in the specification
ERROR: component `server-statistics-packages.yaml` does not exist in the specification
ERROR: component `server-statistics-advisory-db.yaml` does not exist in the specification
ERROR: cannot resolve reference `server-statistics-actions.yaml`, it's missing:  [208172:11]
ERROR: cannot resolve reference `server-statistics-packages.yaml`, it's missing:  [208174:11]
ERROR: cannot resolve reference `server-statistics-advisory-db.yaml`, it's missing:  [208176:11]
ERROR: component `server-statistics-actions.yaml` does not exist in the specification
ERROR: component `server-statistics-packages.yaml` does not exist in the specification
ERROR: component `server-statistics-advisory-db.yaml` does not exist in the specification
ERROR: cannot resolve reference `server-statistics-actions.yaml`, it's missing:  [208169:11]
ERROR: cannot resolve reference `server-statistics-packages.yaml`, it's missing:  [208171:11]
ERROR: cannot resolve reference `server-statistics-advisory-db.yaml`, it's missing:  [208173:11]
