### PR TITLE
[GitHubEnterpriseCloud] Update to 1.1.4-a247d04d83e33358686d7fa8ff2bbf1c from 1.1.4-40f7495bbfb76a67ec180340807d94b8

### DIFF
--- a/clients/GitHubEnterpriseCloud/etc/openapi-client-generator.state
+++ b/clients/GitHubEnterpriseCloud/etc/openapi-client-generator.state
@@ -1,5 +1,5 @@
 {
-    "specHash": "40f7495bbfb76a67ec180340807d94b8",
+    "specHash": "a247d04d83e33358686d7fa8ff2bbf1c",
     "generatedFiles": {
         "files": [
             {
@@ -5920,7 +5920,7 @@
             },
             {
                 "name": ".\/clients\/GitHubEnterpriseCloud\/etc\/..\/\/src\/\/Operation\/Issues.php",
-                "hash": "e1ee990ebfb7ef25d38ad7c4a4d7b2ad"
+                "hash": "b4191035e2fce2587aa3fdae047b4d13"
             },
             {
                 "name": ".\/clients\/GitHubEnterpriseCloud\/etc\/..\/\/src\/\/Operation\/Licenses.php",


### PR DESCRIPTION
Detected Schema changes:
2024-12-03 17:33:09 ERROR unable to open the rolodex file, check specification references and base path
                      ├ file: /__w/github-root/github-root/server-statistics-actions.yaml
                      └ error: open /__w/github-root/github-root/server-statistics-actions.yaml: no such file or directory
2024-12-03 17:33:09 ERROR unable to open the rolodex file, check specification references and base path
                      ├ file: /__w/github-root/github-root/server-statistics-packages.yaml
                      └ error: open /__w/github-root/github-root/server-statistics-packages.yaml: no such file or directory
2024-12-03 17:33:09 ERROR unable to open the rolodex file, check specification references and base path
                      ├ file: /__w/github-root/github-root/server-statistics-advisory-db.yaml
                      └ error: open /__w/github-root/github-root/server-statistics-advisory-db.yaml: no such file or directory
2024-12-03 17:33:11 ERROR unable to open the rolodex file, check specification references and base path
                      ├ error: open /__w/github-root/github-root/server-statistics-actions.yaml: no such file or directory
                      └ file: /__w/github-root/github-root/server-statistics-actions.yaml
2024-12-03 17:33:11 ERROR unable to open the rolodex file, check specification references and base path
                      ├ file: /__w/github-root/github-root/server-statistics-packages.yaml
                      └ error: open /__w/github-root/github-root/server-statistics-packages.yaml: no such file or directory
2024-12-03 17:33:11 ERROR unable to open the rolodex file, check specification references and base path
                      ├ file: /__w/github-root/github-root/server-statistics-advisory-db.yaml
                      └ error: open /__w/github-root/github-root/server-statistics-advisory-db.yaml: no such file or directory
ERROR: component `server-statistics-actions.yaml` does not exist in the specification
ERROR: component `server-statistics-packages.yaml` does not exist in the specification
ERROR: component `server-statistics-advisory-db.yaml` does not exist in the specification
ERROR: cannot resolve reference `server-statistics-actions.yaml`, it's missing:  [210556:11]
ERROR: cannot resolve reference `server-statistics-packages.yaml`, it's missing:  [210558:11]
ERROR: cannot resolve reference `server-statistics-advisory-db.yaml`, it's missing:  [210560:11]
ERROR: component `server-statistics-actions.yaml` does not exist in the specification
ERROR: component `server-statistics-packages.yaml` does not exist in the specification
ERROR: component `server-statistics-advisory-db.yaml` does not exist in the specification
ERROR: cannot resolve reference `server-statistics-actions.yaml`, it's missing:  [210549:11]
ERROR: cannot resolve reference `server-statistics-packages.yaml`, it's missing:  [210551:11]
ERROR: cannot resolve reference `server-statistics-advisory-db.yaml`, it's missing:  [210553:11]
