### PR TITLE
[GitHubEnterpriseCloud] Update to 1.1.4-a247d04d83e33358686d7fa8ff2bbf1c from 1.1.4-a247d04d83e33358686d7fa8ff2bbf1c

### DIFF
--- a/clients/GitHubEnterpriseCloud/etc/openapi-client-generator.state
+++ b/clients/GitHubEnterpriseCloud/etc/openapi-client-generator.state
@@ -33548,7 +33548,7 @@
             },
             {
                 "name": "..\/..\/composer.lock",
-                "hash": "57a58662b6da9a7cae285c7edb32d15d"
+                "hash": "62212c13c50e6b0633b3423bd54d644d"
             }
         ]
     }


### PR DESCRIPTION
Detected Schema changes:
2024-12-04 17:31:19 ERROR unable to open the rolodex file, check specification references and base path
                      ├ file: /__w/github-root/github-root/server-statistics-actions.yaml
                      └ error: open /__w/github-root/github-root/server-statistics-actions.yaml: no such file or directory
2024-12-04 17:31:19 ERROR unable to open the rolodex file, check specification references and base path
                      ├ file: /__w/github-root/github-root/server-statistics-packages.yaml
                      └ error: open /__w/github-root/github-root/server-statistics-packages.yaml: no such file or directory
2024-12-04 17:31:19 ERROR unable to open the rolodex file, check specification references and base path
                      ├ file: /__w/github-root/github-root/server-statistics-advisory-db.yaml
                      └ error: open /__w/github-root/github-root/server-statistics-advisory-db.yaml: no such file or directory
2024-12-04 17:31:21 ERROR unable to open the rolodex file, check specification references and base path
                      ├ error: open /__w/github-root/github-root/server-statistics-actions.yaml: no such file or directory
                      └ file: /__w/github-root/github-root/server-statistics-actions.yaml
2024-12-04 17:31:21 ERROR unable to open the rolodex file, check specification references and base path
                      ├ file: /__w/github-root/github-root/server-statistics-packages.yaml
                      └ error: open /__w/github-root/github-root/server-statistics-packages.yaml: no such file or directory
2024-12-04 17:31:21 ERROR unable to open the rolodex file, check specification references and base path
                      ├ file: /__w/github-root/github-root/server-statistics-advisory-db.yaml
                      └ error: open /__w/github-root/github-root/server-statistics-advisory-db.yaml: no such file or directory
ERROR: component `server-statistics-actions.yaml` does not exist in the specification
ERROR: component `server-statistics-packages.yaml` does not exist in the specification
ERROR: component `server-statistics-advisory-db.yaml` does not exist in the specification
ERROR: cannot resolve reference `server-statistics-actions.yaml`, it's missing:  [210556:11]
ERROR: cannot resolve reference `server-statistics-packages.yaml`, it's missing:  [210558:11]
ERROR: cannot resolve reference `server-statistics-advisory-db.yaml`, it's missing:  [210560:11]
ERROR: component `server-statistics-actions.yaml` does not exist in the specification
ERROR: component `server-statistics-packages.yaml` does not exist in the specification
ERROR: component `server-statistics-advisory-db.yaml` does not exist in the specification
ERROR: cannot resolve reference `server-statistics-actions.yaml`, it's missing:  [210556:11]
ERROR: cannot resolve reference `server-statistics-packages.yaml`, it's missing:  [210558:11]
ERROR: cannot resolve reference `server-statistics-advisory-db.yaml`, it's missing:  [210560:11]
