### PR TITLE
[GitHubEnterprise-3.13] Update to 1.1.4-bb7bf23ece23a331cf9ec11f8b281329 from 1.1.4-8089ef8f95a445cc86353674bade2e6e

### DIFF
--- a/clients/GitHubEnterprise-3.13/etc/openapi-client-generator.state
+++ b/clients/GitHubEnterprise-3.13/etc/openapi-client-generator.state
@@ -1,5 +1,5 @@
 {
-    "specHash": "8089ef8f95a445cc86353674bade2e6e",
+    "specHash": "bb7bf23ece23a331cf9ec11f8b281329",
     "generatedFiles": {
         "files": [
             {
@@ -14460,11 +14460,11 @@
             },
             {
                 "name": ".\/clients\/GitHubEnterprise-3.13\/etc\/..\/\/src\/\/Schema\/CodeScanningDefaultSetup.php",
-                "hash": "1ba7bd43220cfa2954850a5e3782ff55"
+                "hash": "4f690e207f190627e39c7f359282a586"
             },
             {
                 "name": ".\/clients\/GitHubEnterprise-3.13\/etc\/..\/\/src\/\/Schema\/CodeScanningDefaultSetupUpdate.php",
-                "hash": "e527ea3485f737e8621f6ea44930a3ee"
+                "hash": "c914b75e603183fe261e16f7135c6f83"
             },
             {
                 "name": ".\/clients\/GitHubEnterprise-3.13\/etc\/..\/\/src\/\/Schema\/CodeScanningDefaultSetupUpdateResponse.php",

--- a/clients/GitHubEnterprise-3.13/src/Schema/CodeScanningDefaultSetup.php
+++ b/clients/GitHubEnterprise-3.13/src/Schema/CodeScanningDefaultSetup.php
@@ -23,6 +23,7 @@ final readonly class CodeScanningDefaultSetup
             "type": "array",
             "items": {
                 "enum": [
+                    "actions",
                     "c-cpp",
                     "csharp",
                     "go",

--- a/clients/GitHubEnterprise-3.13/src/Schema/CodeScanningDefaultSetupUpdate.php
+++ b/clients/GitHubEnterprise-3.13/src/Schema/CodeScanningDefaultSetupUpdate.php
@@ -31,6 +31,7 @@ final readonly class CodeScanningDefaultSetupUpdate
             "type": "array",
             "items": {
                 "enum": [
+                    "actions",
                     "c-cpp",
                     "csharp",
                     "go",


### PR DESCRIPTION
Detected Schema changes:



```
└─┬Components
  ├─┬code-scanning-default-setup
  │ └─┬languages
  │   └─┬Schema
  │     └──[➖] enum (80374:15)❌ 
  └─┬code-scanning-default-setup-update
    └─┬languages
      └─┬Schema
        └──[➖] enum (80429:15)❌ 

```

| Document Element | Total Changes | Breaking Changes |
|------------------|---------------|------------------|
| components       | 2             | 2                |

Date: 12/20/24 | Commit: New: etc/specs/GitHubEnterprise-3.13/previous.spec.yaml, Original: etc/specs/GitHubEnterprise-3.13/current.spec.yaml

- ❌ **BREAKING Changes**: _2_ out of _2_
- **Removals**: _2_
- **Breaking Removals**: _2_

ERROR: breaking changes discovered
