### PR TITLE
[GitHubEnterprise-3.14] Update to 1.1.4-bd6820e03c74d20458b48da696efedec from 1.1.4-e9e561609727200e583d8b0b8e5feeb1

### DIFF
--- a/clients/GitHubEnterprise-3.14/etc/openapi-client-generator.state
+++ b/clients/GitHubEnterprise-3.14/etc/openapi-client-generator.state
@@ -1,5 +1,5 @@
 {
-    "specHash": "e9e561609727200e583d8b0b8e5feeb1",
+    "specHash": "bd6820e03c74d20458b48da696efedec",
     "generatedFiles": {
         "files": [
             {
@@ -14656,11 +14656,11 @@
             },
             {
                 "name": ".\/clients\/GitHubEnterprise-3.14\/etc\/..\/\/src\/\/Schema\/CodeScanningDefaultSetup.php",
-                "hash": "1ba7bd43220cfa2954850a5e3782ff55"
+                "hash": "4f690e207f190627e39c7f359282a586"
             },
             {
                 "name": ".\/clients\/GitHubEnterprise-3.14\/etc\/..\/\/src\/\/Schema\/CodeScanningDefaultSetupUpdate.php",
-                "hash": "e527ea3485f737e8621f6ea44930a3ee"
+                "hash": "c914b75e603183fe261e16f7135c6f83"
             },
             {
                 "name": ".\/clients\/GitHubEnterprise-3.14\/etc\/..\/\/src\/\/Schema\/CodeScanningDefaultSetupUpdateResponse.php",

--- a/clients/GitHubEnterprise-3.14/src/Schema/CodeScanningDefaultSetup.php
+++ b/clients/GitHubEnterprise-3.14/src/Schema/CodeScanningDefaultSetup.php
@@ -23,6 +23,7 @@ final readonly class CodeScanningDefaultSetup
             "type": "array",
             "items": {
                 "enum": [
+                    "actions",
                     "c-cpp",
                     "csharp",
                     "go",

--- a/clients/GitHubEnterprise-3.14/src/Schema/CodeScanningDefaultSetupUpdate.php
+++ b/clients/GitHubEnterprise-3.14/src/Schema/CodeScanningDefaultSetupUpdate.php
@@ -31,6 +31,7 @@ final readonly class CodeScanningDefaultSetupUpdate
             "type": "array",
             "items": {
                 "enum": [
+                    "actions",
                     "c-cpp",
                     "csharp",
                     "go",


### PR DESCRIPTION
Detected Schema changes:



```
└─┬Components
  ├─┬code-scanning-default-setup-update
  │ └─┬languages
  │   └─┬Schema
  │     └──[➖] enum (81794:15)❌ 
  └─┬code-scanning-default-setup
    └─┬languages
      └─┬Schema
        └──[➖] enum (81739:15)❌ 

```

| Document Element | Total Changes | Breaking Changes |
|------------------|---------------|------------------|
| components       | 2             | 2                |

Date: 12/20/24 | Commit: New: etc/specs/GitHubEnterprise-3.14/previous.spec.yaml, Original: etc/specs/GitHubEnterprise-3.14/current.spec.yaml

- ❌ **BREAKING Changes**: _2_ out of _2_
- **Removals**: _2_
- **Breaking Removals**: _2_

ERROR: breaking changes discovered
