### PR TITLE
[GitHubEnterpriseCloud] Update to 1.1.4-79449ce7df3e3a8b4c97032f07cbaae3 from 1.1.4-9e7ab390ae84353f100b5db1dbcb3339

### DIFF
--- a/clients/GitHubEnterpriseCloud/etc/openapi-client-generator.state
+++ b/clients/GitHubEnterpriseCloud/etc/openapi-client-generator.state
@@ -1,5 +1,5 @@
 {
-    "specHash": "9e7ab390ae84353f100b5db1dbcb3339",
+    "specHash": "79449ce7df3e3a8b4c97032f07cbaae3",
     "generatedFiles": {
         "files": [
             {
@@ -1740,27 +1740,27 @@
             },
             {
                 "name": ".\/clients\/GitHubEnterpriseCloud\/etc\/..\/\/src\/\/Schema\/WebhookCodeScanningAlertAppearedInBranch.php",
-                "hash": "310d039740c8c11ce02a2dd97abf3728"
+                "hash": "f602659613c03a0f09ef04b594f2c52f"
             },
             {
                 "name": ".\/clients\/GitHubEnterpriseCloud\/etc\/..\/\/src\/\/Schema\/WebhookCodeScanningAlertClosedByUser.php",
-                "hash": "cb61ea5a783e4e884c20b28b6ea27187"
+                "hash": "7b05e732b104e76f0b27c69615d8db8a"
             },
             {
                 "name": ".\/clients\/GitHubEnterpriseCloud\/etc\/..\/\/src\/\/Schema\/WebhookCodeScanningAlertCreated.php",
-                "hash": "c55c7f38a87ebee5660d269d817bbb24"
+                "hash": "af37dab598509c3cdf02b3a704fc1eca"
             },
             {
                 "name": ".\/clients\/GitHubEnterpriseCloud\/etc\/..\/\/src\/\/Schema\/WebhookCodeScanningAlertFixed.php",
-                "hash": "fc0bd9449d778eb891235bfb2209140b"
+                "hash": "396cf1f9223b7b75ac03c31f5fcd912b"
             },
             {
                 "name": ".\/clients\/GitHubEnterpriseCloud\/etc\/..\/\/src\/\/Schema\/WebhookCodeScanningAlertReopened.php",
-                "hash": "548fe341fac76b8410ce1126e6a1e759"
+                "hash": "0705294574415fab2dc6d4373f8d53d9"
             },
             {
                 "name": ".\/clients\/GitHubEnterpriseCloud\/etc\/..\/\/src\/\/Schema\/WebhookCodeScanningAlertReopenedByUser.php",
-                "hash": "3a8429d73269ef55c34c346b80924e5a"
+                "hash": "cc1b50911951c24f1ec4003bdb23dba6"
             },
             {
                 "name": ".\/clients\/GitHubEnterpriseCloud\/etc\/..\/\/src\/\/Schema\/WebhookCommitCommentCreated.php",
@@ -3568,7 +3568,7 @@
             },
             {
                 "name": ".\/clients\/GitHubEnterpriseCloud\/etc\/..\/\/src\/\/Schema\/WebhookCodeScanningAlertAppearedInBranch\/Alert.php",
-                "hash": "6c37c410a4357f02253e68559b1bc054"
+                "hash": "65c31d68b4d5300ca4bae344402a87cd"
             },
             {
                 "name": ".\/clients\/GitHubEnterpriseCloud\/etc\/..\/\/src\/\/Schema\/WebhookCodeScanningAlertAppearedInBranch\/Alert\/MostRecentInstance.php",
@@ -3588,7 +3588,7 @@
             },
             {
                 "name": ".\/clients\/GitHubEnterpriseCloud\/etc\/..\/\/src\/\/Schema\/WebhookCodeScanningAlertClosedByUser\/Alert.php",
-                "hash": "d2f83984a5aeeb2bc9d7e60076b85133"
+                "hash": "3a5f56776d37230d5cf3f0e7f6322c72"
             },
             {
                 "name": ".\/clients\/GitHubEnterpriseCloud\/etc\/..\/\/src\/\/Schema\/WebhookCodeScanningAlertClosedByUser\/Alert\/Rule.php",
@@ -3600,7 +3600,7 @@
             },
             {
                 "name": ".\/clients\/GitHubEnterpriseCloud\/etc\/..\/\/src\/\/Schema\/WebhookCodeScanningAlertCreated\/Alert.php",
-                "hash": "3576c9619c4af8b9fcf65b09b67a3a62"
+                "hash": "52d77e9f14382940f44feec13274cfc5"
             },
             {
                 "name": ".\/clients\/GitHubEnterpriseCloud\/etc\/..\/\/src\/\/Schema\/WebhookCodeScanningAlertCreated\/Alert\/Tool.php",
@@ -3608,15 +3608,15 @@
             },
             {
                 "name": ".\/clients\/GitHubEnterpriseCloud\/etc\/..\/\/src\/\/Schema\/WebhookCodeScanningAlertFixed\/Alert.php",
-                "hash": "8d946e62b3b62f2d5ec7e10a7375b6bc"
+                "hash": "371e5ddd86c3c8de2852adbb61c26db0"
             },
             {
                 "name": ".\/clients\/GitHubEnterpriseCloud\/etc\/..\/\/src\/\/Schema\/WebhookCodeScanningAlertReopened\/Alert.php",
-                "hash": "98934dc2cba40ef07a98abbff7b6dc1c"
+                "hash": "a9fd129f37494ed134a10bf022308c29"
             },
             {
                 "name": ".\/clients\/GitHubEnterpriseCloud\/etc\/..\/\/src\/\/Schema\/WebhookCodeScanningAlertReopenedByUser\/Alert.php",
-                "hash": "7d4f486c182484d0cb6ca9e6ddc2fc42"
+                "hash": "5dc04255770762a3f704643eefb3f08a"
             },
             {
                 "name": ".\/clients\/GitHubEnterpriseCloud\/etc\/..\/\/src\/\/Schema\/WebhookCommitCommentCreated\/Comment.php",
@@ -30028,7 +30028,7 @@
             },
             {
                 "name": ".\/clients\/GitHubEnterpriseCloud\/etc\/..\/\/src\/\/Internal\/Hydrator\/WebHook\/CodeScanningAlert.php",
-                "hash": "df362d4ab3e14516d979aa673434dea3"
+                "hash": "39488483d791cd0fad5806b0d4ddc491"
             },
             {
                 "name": ".\/clients\/GitHubEnterpriseCloud\/etc\/..\/\/src\/\/Internal\/Hydrator\/WebHook\/CommitComment.php",

--- a/clients/GitHubEnterpriseCloud/src/Internal/Hydrator/WebHook/CodeScanningAlert.php
+++ b/clients/GitHubEnterpriseCloud/src/Internal/Hydrator/WebHook/CodeScanningAlert.php
@@ -342,6 +342,17 @@ class CodeScanningAlert implements ObjectMapper
 
             after_dismissedBy:
 
+            $value = $payload['dismissed_comment'] ?? null;
+
+            if ($value === null) {
+                $properties['dismissedComment'] = null;
+                goto after_dismissedComment;
+            }
+
+            $properties['dismissedComment'] = $value;
+
+            after_dismissedComment:
+
             $value = $payload['dismissed_reason'] ?? null;
 
             if ($value === null) {
@@ -352,6 +363,17 @@ class CodeScanningAlert implements ObjectMapper
             $properties['dismissedReason'] = $value;
 
             after_dismissedReason:
+
+            $value = $payload['fixed_at'] ?? null;
+
+            if ($value === null) {
+                $missingFields[] = 'fixed_at';
+                goto after_fixedAt;
+            }
+
+            $properties['fixedAt'] = $value;
+
+            after_fixedAt:
 
             $value = $payload['html_url'] ?? null;
 
@@ -418,7 +440,7 @@ class CodeScanningAlert implements ObjectMapper
             $value = $payload['state'] ?? null;
 
             if ($value === null) {
-                $missingFields[] = 'state';
+                $properties['state'] = null;
                 goto after_state;
             }
 
@@ -4483,6 +4505,17 @@ class CodeScanningAlert implements ObjectMapper
 
             after_dismissedBy:
 
+            $value = $payload['dismissed_comment'] ?? null;
+
+            if ($value === null) {
+                $properties['dismissedComment'] = null;
+                goto after_dismissedComment;
+            }
+
+            $properties['dismissedComment'] = $value;
+
+            after_dismissedComment:
+
             $value = $payload['dismissed_reason'] ?? null;
 
             if ($value === null) {
@@ -4493,6 +4526,17 @@ class CodeScanningAlert implements ObjectMapper
             $properties['dismissedReason'] = $value;
 
             after_dismissedReason:
+
+            $value = $payload['fixed_at'] ?? null;
+
+            if ($value === null) {
+                $missingFields[] = 'fixed_at';
+                goto after_fixedAt;
+            }
+
+            $properties['fixedAt'] = $value;
+
+            after_fixedAt:
 
             $value = $payload['html_url'] ?? null;
 
@@ -6273,6 +6317,17 @@ class CodeScanningAlert implements ObjectMapper
 
             after_dismissedBy:
 
+            $value = $payload['dismissed_comment'] ?? null;
+
+            if ($value === null) {
+                $properties['dismissedComment'] = null;
+                goto after_dismissedComment;
+            }
+
+            $properties['dismissedComment'] = $value;
+
+            after_dismissedComment:
+
             $value = $payload['dismissed_reason'] ?? null;
 
             if ($value === null) {
@@ -6283,6 +6338,17 @@ class CodeScanningAlert implements ObjectMapper
             $properties['dismissedReason'] = $value;
 
             after_dismissedReason:
+
+            $value = $payload['fixed_at'] ?? null;
+
+            if ($value === null) {
+                $missingFields[] = 'fixed_at';
+                goto after_fixedAt;
+            }
+
+            $properties['fixedAt'] = $value;
+
+            after_fixedAt:
 
             $value = $payload['html_url'] ?? null;
 
@@ -6360,7 +6426,7 @@ class CodeScanningAlert implements ObjectMapper
             $value = $payload['state'] ?? null;
 
             if ($value === null) {
-                $missingFields[] = 'state';
+                $properties['state'] = null;
                 goto after_state;
             }
 
@@ -7292,6 +7358,17 @@ class CodeScanningAlert implements ObjectMapper
 
             after_dismissedBy:
 
+            $value = $payload['dismissed_comment'] ?? null;
+
+            if ($value === null) {
+                $properties['dismissedComment'] = null;
+                goto after_dismissedComment;
+            }
+
+            $properties['dismissedComment'] = $value;
+
+            after_dismissedComment:
+
             $value = $payload['dismissed_reason'] ?? null;
 
             if ($value === null) {
@@ -7302,6 +7379,17 @@ class CodeScanningAlert implements ObjectMapper
             $properties['dismissedReason'] = $value;
 
             after_dismissedReason:
+
+            $value = $payload['fixed_at'] ?? null;
+
+            if ($value === null) {
+                $missingFields[] = 'fixed_at';
+                goto after_fixedAt;
+            }
+
+            $properties['fixedAt'] = $value;
+
+            after_fixedAt:
 
             $value = $payload['html_url'] ?? null;
 
@@ -7368,7 +7456,7 @@ class CodeScanningAlert implements ObjectMapper
             $value = $payload['state'] ?? null;
 
             if ($value === null) {
-                $missingFields[] = 'state';
+                $properties['state'] = null;
                 goto after_state;
             }
 
@@ -8030,6 +8118,17 @@ class CodeScanningAlert implements ObjectMapper
 
             after_dismissedBy:
 
+            $value = $payload['dismissed_comment'] ?? null;
+
+            if ($value === null) {
+                $properties['dismissedComment'] = null;
+                goto after_dismissedComment;
+            }
+
+            $properties['dismissedComment'] = $value;
+
+            after_dismissedComment:
+
             $value = $payload['dismissed_reason'] ?? null;
 
             if ($value === null) {
@@ -8040,6 +8139,17 @@ class CodeScanningAlert implements ObjectMapper
             $properties['dismissedReason'] = $value;
 
             after_dismissedReason:
+
+            $value = $payload['fixed_at'] ?? null;
+
+            if ($value === null) {
+                $missingFields[] = 'fixed_at';
+                goto after_fixedAt;
+            }
+
+            $properties['fixedAt'] = $value;
+
+            after_fixedAt:
 
             $value = $payload['html_url'] ?? null;
 
@@ -8106,7 +8216,7 @@ class CodeScanningAlert implements ObjectMapper
             $value = $payload['state'] ?? null;
 
             if ($value === null) {
-                $missingFields[] = 'state';
+                $properties['state'] = null;
                 goto after_state;
             }
 
@@ -8761,6 +8871,14 @@ class CodeScanningAlert implements ObjectMapper
         $dismissedBy                                      = $this->serializeObjectApiClients⚡️Client⚡️GitHubEnterpriseCloud⚡️Schema⚡️WebhookCodeScanningAlertAppearedInBranch⚡️Alert⚡️DismissedBy($dismissedBy);
         after_dismissedBy:        $result['dismissed_by'] = $dismissedBy;
 
+        $dismissedComment = $object->dismissedComment;
+
+        if ($dismissedComment === null) {
+            goto after_dismissedComment;
+        }
+
+        after_dismissedComment:        $result['dismissed_comment'] = $dismissedComment;
+
         $dismissedReason = $object->dismissedReason;
 
         if ($dismissedReason === null) {
@@ -8768,6 +8886,9 @@ class CodeScanningAlert implements ObjectMapper
         }
 
         after_dismissedReason:        $result['dismissed_reason'] = $dismissedReason;
+
+        $fixedAt                                  = $object->fixedAt;
+        after_fixedAt:        $result['fixed_at'] = $fixedAt;
 
         $htmlUrl                                  = $object->htmlUrl;
         after_htmlUrl:        $result['html_url'] = $htmlUrl;
@@ -8788,7 +8909,12 @@ class CodeScanningAlert implements ObjectMapper
         $rule                              = $this->serializeObjectApiClients⚡️Client⚡️GitHubEnterpriseCloud⚡️Schema⚡️WebhookCodeScanningAlertAppearedInBranch⚡️Alert⚡️Rule($rule);
         after_rule:        $result['rule'] = $rule;
 
-        $state                               = $object->state;
+        $state = $object->state;
+
+        if ($state === null) {
+            goto after_state;
+        }
+
         after_state:        $result['state'] = $state;
 
         $tool                              = $object->tool;
@@ -10928,6 +11054,14 @@ class CodeScanningAlert implements ObjectMapper
         $dismissedBy                                      = $this->serializeObjectApiClients⚡️Client⚡️GitHubEnterpriseCloud⚡️Schema⚡️WebhookCodeScanningAlertClosedByUser⚡️Alert⚡️DismissedBy($dismissedBy);
         after_dismissedBy:        $result['dismissed_by'] = $dismissedBy;
 
+        $dismissedComment = $object->dismissedComment;
+
+        if ($dismissedComment === null) {
+            goto after_dismissedComment;
+        }
+
+        after_dismissedComment:        $result['dismissed_comment'] = $dismissedComment;
+
         $dismissedReason = $object->dismissedReason;
 
         if ($dismissedReason === null) {
@@ -10935,6 +11069,9 @@ class CodeScanningAlert implements ObjectMapper
         }
 
         after_dismissedReason:        $result['dismissed_reason'] = $dismissedReason;
+
+        $fixedAt                                  = $object->fixedAt;
+        after_fixedAt:        $result['fixed_at'] = $fixedAt;
 
         $htmlUrl                                  = $object->htmlUrl;
         after_htmlUrl:        $result['html_url'] = $htmlUrl;
@@ -11828,6 +11965,14 @@ class CodeScanningAlert implements ObjectMapper
         $dismissedBy                                      = $this->serializeObjectApiClients⚡️Client⚡️GitHubEnterpriseCloud⚡️Schema⚡️WebhookCodeScanningAlertFixed⚡️Alert⚡️DismissedBy($dismissedBy);
         after_dismissedBy:        $result['dismissed_by'] = $dismissedBy;
 
+        $dismissedComment = $object->dismissedComment;
+
+        if ($dismissedComment === null) {
+            goto after_dismissedComment;
+        }
+
+        after_dismissedComment:        $result['dismissed_comment'] = $dismissedComment;
+
         $dismissedReason = $object->dismissedReason;
 
         if ($dismissedReason === null) {
@@ -11835,6 +11980,9 @@ class CodeScanningAlert implements ObjectMapper
         }
 
         after_dismissedReason:        $result['dismissed_reason'] = $dismissedReason;
+
+        $fixedAt                                  = $object->fixedAt;
+        after_fixedAt:        $result['fixed_at'] = $fixedAt;
 
         $htmlUrl                                  = $object->htmlUrl;
         after_htmlUrl:        $result['html_url'] = $htmlUrl;
@@ -11863,7 +12011,12 @@ class CodeScanningAlert implements ObjectMapper
         $rule                              = $this->serializeObjectApiClients⚡️Client⚡️GitHubEnterpriseCloud⚡️Schema⚡️WebhookCodeScanningAlertFixed⚡️Alert⚡️Rule($rule);
         after_rule:        $result['rule'] = $rule;
 
-        $state                               = $object->state;
+        $state = $object->state;
+
+        if ($state === null) {
+            goto after_state;
+        }
+
         after_state:        $result['state'] = $state;
 
         $tool                              = $object->tool;
@@ -12375,6 +12528,14 @@ class CodeScanningAlert implements ObjectMapper
         $dismissedBy                                      = $this->serializeObjectApiClients⚡️Client⚡️GitHubEnterpriseCloud⚡️Schema⚡️WebhookCodeScanningAlertReopened⚡️Alert⚡️DismissedBy($dismissedBy);
         after_dismissedBy:        $result['dismissed_by'] = $dismissedBy;
 
+        $dismissedComment = $object->dismissedComment;
+
+        if ($dismissedComment === null) {
+            goto after_dismissedComment;
+        }
+
+        after_dismissedComment:        $result['dismissed_comment'] = $dismissedComment;
+
         $dismissedReason = $object->dismissedReason;
 
         if ($dismissedReason === null) {
@@ -12382,6 +12543,9 @@ class CodeScanningAlert implements ObjectMapper
         }
 
         after_dismissedReason:        $result['dismissed_reason'] = $dismissedReason;
+
+        $fixedAt                                  = $object->fixedAt;
+        after_fixedAt:        $result['fixed_at'] = $fixedAt;
 
         $htmlUrl                                  = $object->htmlUrl;
         after_htmlUrl:        $result['html_url'] = $htmlUrl;
@@ -12402,7 +12566,12 @@ class CodeScanningAlert implements ObjectMapper
         $rule                              = $this->serializeObjectApiClients⚡️Client⚡️GitHubEnterpriseCloud⚡️Schema⚡️WebhookCodeScanningAlertReopened⚡️Alert⚡️Rule($rule);
         after_rule:        $result['rule'] = $rule;
 
-        $state                               = $object->state;
+        $state = $object->state;
+
+        if ($state === null) {
+            goto after_state;
+        }
+
         after_state:        $result['state'] = $state;
 
         $tool                              = $object->tool;
@@ -12714,8 +12883,19 @@ class CodeScanningAlert implements ObjectMapper
         $dismissedBy                                      = $object->dismissedBy;
         after_dismissedBy:        $result['dismissed_by'] = $dismissedBy;
 
+        $dismissedComment = $object->dismissedComment;
+
+        if ($dismissedComment === null) {
+            goto after_dismissedComment;
+        }
+
+        after_dismissedComment:        $result['dismissed_comment'] = $dismissedComment;
+
         $dismissedReason                                          = $object->dismissedReason;
         after_dismissedReason:        $result['dismissed_reason'] = $dismissedReason;
+
+        $fixedAt                                  = $object->fixedAt;
+        after_fixedAt:        $result['fixed_at'] = $fixedAt;
 
         $htmlUrl                                  = $object->htmlUrl;
         after_htmlUrl:        $result['html_url'] = $htmlUrl;
@@ -12736,7 +12916,12 @@ class CodeScanningAlert implements ObjectMapper
         $rule                              = $this->serializeObjectApiClients⚡️Client⚡️GitHubEnterpriseCloud⚡️Schema⚡️WebhookCodeScanningAlertReopenedByUser⚡️Alert⚡️Rule($rule);
         after_rule:        $result['rule'] = $rule;
 
-        $state                               = $object->state;
+        $state = $object->state;
+
+        if ($state === null) {
+            goto after_state;
+        }
+
         after_state:        $result['state'] = $state;
 
         $tool                              = $object->tool;

--- a/clients/GitHubEnterpriseCloud/src/Schema/WebhookCodeScanningAlertAppearedInBranch.php
+++ b/clients/GitHubEnterpriseCloud/src/Schema/WebhookCodeScanningAlertAppearedInBranch.php
@@ -154,6 +154,14 @@ final readonly class WebhookCodeScanningAlertAppearedInBranch
                         }
                     }
                 },
+                "dismissed_comment": {
+                    "maxLength": 280,
+                    "type": [
+                        "string",
+                        "null"
+                    ],
+                    "description": "The dismissal comment associated with the dismissal of the alert."
+                },
                 "dismissed_reason": {
                     "enum": [
                         "false positive",
@@ -166,6 +174,12 @@ final readonly class WebhookCodeScanningAlertAppearedInBranch
                         "null"
                     ],
                     "description": "The reason for dismissing or closing the alert."
+                },
+                "fixed_at": {
+                    "type": [
+                        "null"
+                    ],
+                    "description": "The time that the alert was fixed in ISO 8601 format: `YYYY-MM-DDTHH:MM:SSZ`."
                 },
                 "html_url": {
                     "type": "string",
@@ -289,10 +303,14 @@ final readonly class WebhookCodeScanningAlertAppearedInBranch
                     "enum": [
                         "open",
                         "dismissed",
-                        "fixed"
+                        "fixed",
+                        null
                     ],
-                    "type": "string",
-                    "description": "State of a code scanning alert."
+                    "type": [
+                        "string",
+                        "null"
+                    ],
+                    "description": "State of a code scanning alert. Events for alerts found outside the default branch will return a `null` value until they are dismissed or fixed."
                 },
                 "tool": {
                     "required": [
@@ -2233,7 +2251,9 @@ final readonly class WebhookCodeScanningAlertAppearedInBranch
             "url": "https:\\/\\/example.com\\/",
             "user_view_type": "generated"
         },
+        "dismissed_comment": "generated",
         "dismissed_reason": "used in tests",
+        "fixed_at": "generated",
         "html_url": "https:\\/\\/example.com\\/",
         "most_recent_instance": {
             "analysis_key": "generated",

--- a/clients/GitHubEnterpriseCloud/src/Schema/WebhookCodeScanningAlertAppearedInBranch/Alert.php
+++ b/clients/GitHubEnterpriseCloud/src/Schema/WebhookCodeScanningAlertAppearedInBranch/Alert.php
@@ -136,6 +136,14 @@ final readonly class Alert
                 }
             }
         },
+        "dismissed_comment": {
+            "maxLength": 280,
+            "type": [
+                "string",
+                "null"
+            ],
+            "description": "The dismissal comment associated with the dismissal of the alert."
+        },
         "dismissed_reason": {
             "enum": [
                 "false positive",
@@ -148,6 +156,12 @@ final readonly class Alert
                 "null"
             ],
             "description": "The reason for dismissing or closing the alert."
+        },
+        "fixed_at": {
+            "type": [
+                "null"
+            ],
+            "description": "The time that the alert was fixed in ISO 8601 format: `YYYY-MM-DDTHH:MM:SSZ`."
         },
         "html_url": {
             "type": "string",
@@ -271,10 +285,14 @@ final readonly class Alert
             "enum": [
                 "open",
                 "dismissed",
-                "fixed"
+                "fixed",
+                null
             ],
-            "type": "string",
-            "description": "State of a code scanning alert."
+            "type": [
+                "string",
+                "null"
+            ],
+            "description": "State of a code scanning alert. Events for alerts found outside the default branch will return a `null` value until they are dismissed or fixed."
         },
         "tool": {
             "required": [
@@ -332,7 +350,9 @@ final readonly class Alert
         "url": "https:\\/\\/example.com\\/",
         "user_view_type": "generated"
     },
+    "dismissed_comment": "generated",
     "dismissed_reason": "used in tests",
+    "fixed_at": "generated",
     "html_url": "https:\\/\\/example.com\\/",
     "most_recent_instance": {
         "analysis_key": "generated",
@@ -373,18 +393,22 @@ final readonly class Alert
     /**
      * createdAt: The time that the alert was created in ISO 8601 format: `YYYY-MM-DDTHH:MM:SSZ.`
      * dismissedAt: The time that the alert was dismissed in ISO 8601 format: `YYYY-MM-DDTHH:MM:SSZ`.
+     * dismissedComment: The dismissal comment associated with the dismissal of the alert.
      * dismissedReason: The reason for dismissing or closing the alert.
+     * fixedAt: The time that the alert was fixed in ISO 8601 format: `YYYY-MM-DDTHH:MM:SSZ`.
      * htmlUrl: The GitHub URL of the alert resource.
      * number: The code scanning alert number.
-     * state: State of a code scanning alert.
+     * state: State of a code scanning alert. Events for alerts found outside the default branch will return a `null` value until they are dismissed or fixed.
      */
     public function __construct(#[MapFrom('created_at')]
     public string $createdAt, #[MapFrom('dismissed_at')]
     public string|null $dismissedAt, #[MapFrom('dismissed_by')]
-    public Schema\WebhookCodeScanningAlertAppearedInBranch\Alert\DismissedBy|null $dismissedBy, #[MapFrom('dismissed_reason')]
-    public string|null $dismissedReason, #[MapFrom('html_url')]
+    public Schema\WebhookCodeScanningAlertAppearedInBranch\Alert\DismissedBy|null $dismissedBy, #[MapFrom('dismissed_comment')]
+    public string|null $dismissedComment, #[MapFrom('dismissed_reason')]
+    public string|null $dismissedReason, #[MapFrom('fixed_at')]
+    public string $fixedAt, #[MapFrom('html_url')]
     public string $htmlUrl, #[MapFrom('most_recent_instance')]
-    public Schema\WebhookCodeScanningAlertAppearedInBranch\Alert\MostRecentInstance|null $mostRecentInstance, public int $number, public Schema\WebhookCodeScanningAlertAppearedInBranch\Alert\Rule $rule, public string $state, public Schema\WebhookCodeScanningAlertAppearedInBranch\Alert\Tool $tool, public string $url,)
+    public Schema\WebhookCodeScanningAlertAppearedInBranch\Alert\MostRecentInstance|null $mostRecentInstance, public int $number, public Schema\WebhookCodeScanningAlertAppearedInBranch\Alert\Rule $rule, public string|null $state, public Schema\WebhookCodeScanningAlertAppearedInBranch\Alert\Tool $tool, public string $url,)
     {
     }
 }

--- a/clients/GitHubEnterpriseCloud/src/Schema/WebhookCodeScanningAlertClosedByUser.php
+++ b/clients/GitHubEnterpriseCloud/src/Schema/WebhookCodeScanningAlertClosedByUser.php
@@ -151,6 +151,14 @@ final readonly class WebhookCodeScanningAlertClosedByUser
                         }
                     }
                 },
+                "dismissed_comment": {
+                    "maxLength": 280,
+                    "type": [
+                        "string",
+                        "null"
+                    ],
+                    "description": "The dismissal comment associated with the dismissal of the alert."
+                },
                 "dismissed_reason": {
                     "enum": [
                         "false positive",
@@ -163,6 +171,12 @@ final readonly class WebhookCodeScanningAlertClosedByUser
                         "null"
                     ],
                     "description": "The reason for dismissing or closing the alert."
+                },
+                "fixed_at": {
+                    "type": [
+                        "null"
+                    ],
+                    "description": "The time that the alert was fixed in ISO 8601 format: `YYYY-MM-DDTHH:MM:SSZ`."
                 },
                 "html_url": {
                     "type": "string",
@@ -2263,7 +2277,9 @@ final readonly class WebhookCodeScanningAlertClosedByUser
             "url": "https:\\/\\/example.com\\/",
             "user_view_type": "generated"
         },
+        "dismissed_comment": "generated",
         "dismissed_reason": "used in tests",
+        "fixed_at": "generated",
         "html_url": "https:\\/\\/example.com\\/",
         "most_recent_instance": {
             "analysis_key": "generated",

--- a/clients/GitHubEnterpriseCloud/src/Schema/WebhookCodeScanningAlertClosedByUser/Alert.php
+++ b/clients/GitHubEnterpriseCloud/src/Schema/WebhookCodeScanningAlertClosedByUser/Alert.php
@@ -133,6 +133,14 @@ final readonly class Alert
                 }
             }
         },
+        "dismissed_comment": {
+            "maxLength": 280,
+            "type": [
+                "string",
+                "null"
+            ],
+            "description": "The dismissal comment associated with the dismissal of the alert."
+        },
         "dismissed_reason": {
             "enum": [
                 "false positive",
@@ -145,6 +153,12 @@ final readonly class Alert
                 "null"
             ],
             "description": "The reason for dismissing or closing the alert."
+        },
+        "fixed_at": {
+            "type": [
+                "null"
+            ],
+            "description": "The time that the alert was fixed in ISO 8601 format: `YYYY-MM-DDTHH:MM:SSZ`."
         },
         "html_url": {
             "type": "string",
@@ -362,7 +376,9 @@ final readonly class Alert
         "url": "https:\\/\\/example.com\\/",
         "user_view_type": "generated"
     },
+    "dismissed_comment": "generated",
     "dismissed_reason": "used in tests",
+    "fixed_at": "generated",
     "html_url": "https:\\/\\/example.com\\/",
     "most_recent_instance": {
         "analysis_key": "generated",
@@ -409,7 +425,9 @@ final readonly class Alert
     /**
      * createdAt: The time that the alert was created in ISO 8601 format: `YYYY-MM-DDTHH:MM:SSZ.`
      * dismissedAt: The time that the alert was dismissed in ISO 8601 format: `YYYY-MM-DDTHH:MM:SSZ`.
+     * dismissedComment: The dismissal comment associated with the dismissal of the alert.
      * dismissedReason: The reason for dismissing or closing the alert.
+     * fixedAt: The time that the alert was fixed in ISO 8601 format: `YYYY-MM-DDTHH:MM:SSZ`.
      * htmlUrl: The GitHub URL of the alert resource.
      * number: The code scanning alert number.
      * state: State of a code scanning alert.
@@ -417,8 +435,10 @@ final readonly class Alert
     public function __construct(#[MapFrom('created_at')]
     public string $createdAt, #[MapFrom('dismissed_at')]
     public string $dismissedAt, #[MapFrom('dismissed_by')]
-    public Schema\WebhookCodeScanningAlertClosedByUser\Alert\DismissedBy|null $dismissedBy, #[MapFrom('dismissed_reason')]
-    public string|null $dismissedReason, #[MapFrom('html_url')]
+    public Schema\WebhookCodeScanningAlertClosedByUser\Alert\DismissedBy|null $dismissedBy, #[MapFrom('dismissed_comment')]
+    public string|null $dismissedComment, #[MapFrom('dismissed_reason')]
+    public string|null $dismissedReason, #[MapFrom('fixed_at')]
+    public string $fixedAt, #[MapFrom('html_url')]
     public string $htmlUrl, #[MapFrom('most_recent_instance')]
     public Schema\WebhookCodeScanningAlertClosedByUser\Alert\MostRecentInstance|null $mostRecentInstance, public int $number, public Schema\WebhookCodeScanningAlertClosedByUser\Alert\Rule $rule, public string $state, public Schema\WebhookCodeScanningAlertClosedByUser\Alert\Tool $tool, public string $url,)
     {

--- a/clients/GitHubEnterpriseCloud/src/Schema/WebhookCodeScanningAlertCreated.php
+++ b/clients/GitHubEnterpriseCloud/src/Schema/WebhookCodeScanningAlertCreated.php
@@ -78,7 +78,8 @@ final readonly class WebhookCodeScanningAlertCreated
                 "fixed_at": {
                     "type": [
                         "null"
-                    ]
+                    ],
+                    "description": "The time that the alert was fixed in ISO 8601 format: `YYYY-MM-DDTHH:MM:SSZ`."
                 },
                 "html_url": {
                     "type": "string",
@@ -239,7 +240,7 @@ final readonly class WebhookCodeScanningAlertCreated
                         "string",
                         "null"
                     ],
-                    "description": "State of a code scanning alert."
+                    "description": "State of a code scanning alert. Events for alerts found outside the default branch will return a `null` value until they are dismissed or fixed."
                 },
                 "tool": {
                     "required": [

--- a/clients/GitHubEnterpriseCloud/src/Schema/WebhookCodeScanningAlertCreated/Alert.php
+++ b/clients/GitHubEnterpriseCloud/src/Schema/WebhookCodeScanningAlertCreated/Alert.php
@@ -60,7 +60,8 @@ final readonly class Alert
         "fixed_at": {
             "type": [
                 "null"
-            ]
+            ],
+            "description": "The time that the alert was fixed in ISO 8601 format: `YYYY-MM-DDTHH:MM:SSZ`."
         },
         "html_url": {
             "type": "string",
@@ -221,7 +222,7 @@ final readonly class Alert
                 "string",
                 "null"
             ],
-            "description": "State of a code scanning alert."
+            "description": "State of a code scanning alert. Events for alerts found outside the default branch will return a `null` value until they are dismissed or fixed."
         },
         "tool": {
             "required": [
@@ -324,9 +325,10 @@ final readonly class Alert
      * dismissedAt: The time that the alert was dismissed in ISO 8601 format: `YYYY-MM-DDTHH:MM:SSZ`.
      * dismissedComment: The dismissal comment associated with the dismissal of the alert.
      * dismissedReason: The reason for dismissing or closing the alert. Can be one of: `false positive`, `won't fix`, and `used in tests`.
+     * fixedAt: The time that the alert was fixed in ISO 8601 format: `YYYY-MM-DDTHH:MM:SSZ`.
      * htmlUrl: The GitHub URL of the alert resource.
      * number: The code scanning alert number.
-     * state: State of a code scanning alert.
+     * state: State of a code scanning alert. Events for alerts found outside the default branch will return a `null` value until they are dismissed or fixed.
      */
     public function __construct(#[MapFrom('created_at')]
     public string|null $createdAt, #[MapFrom('dismissed_at')]

--- a/clients/GitHubEnterpriseCloud/src/Schema/WebhookCodeScanningAlertFixed.php
+++ b/clients/GitHubEnterpriseCloud/src/Schema/WebhookCodeScanningAlertFixed.php
@@ -154,6 +154,14 @@ final readonly class WebhookCodeScanningAlertFixed
                         }
                     }
                 },
+                "dismissed_comment": {
+                    "maxLength": 280,
+                    "type": [
+                        "string",
+                        "null"
+                    ],
+                    "description": "The dismissal comment associated with the dismissal of the alert."
+                },
                 "dismissed_reason": {
                     "enum": [
                         "false positive",
@@ -166,6 +174,12 @@ final readonly class WebhookCodeScanningAlertFixed
                         "null"
                     ],
                     "description": "The reason for dismissing or closing the alert."
+                },
+                "fixed_at": {
+                    "type": [
+                        "null"
+                    ],
+                    "description": "The time that the alert was fixed in ISO 8601 format: `YYYY-MM-DDTHH:MM:SSZ`."
                 },
                 "html_url": {
                     "type": "string",
@@ -319,10 +333,14 @@ final readonly class WebhookCodeScanningAlertFixed
                 },
                 "state": {
                     "enum": [
-                        "fixed"
+                        "fixed",
+                        null
                     ],
-                    "type": "string",
-                    "description": "State of a code scanning alert."
+                    "type": [
+                        "string",
+                        "null"
+                    ],
+                    "description": "State of a code scanning alert. Events for alerts found outside the default branch will return a `null` value until they are dismissed or fixed."
                 },
                 "tool": {
                     "required": [
@@ -2269,7 +2287,9 @@ final readonly class WebhookCodeScanningAlertFixed
             "url": "https:\\/\\/example.com\\/",
             "user_view_type": "generated"
         },
+        "dismissed_comment": "generated",
         "dismissed_reason": "used in tests",
+        "fixed_at": "generated",
         "html_url": "https:\\/\\/example.com\\/",
         "instances_url": "https:\\/\\/example.com\\/",
         "most_recent_instance": {

--- a/clients/GitHubEnterpriseCloud/src/Schema/WebhookCodeScanningAlertFixed/Alert.php
+++ b/clients/GitHubEnterpriseCloud/src/Schema/WebhookCodeScanningAlertFixed/Alert.php
@@ -136,6 +136,14 @@ final readonly class Alert
                 }
             }
         },
+        "dismissed_comment": {
+            "maxLength": 280,
+            "type": [
+                "string",
+                "null"
+            ],
+            "description": "The dismissal comment associated with the dismissal of the alert."
+        },
         "dismissed_reason": {
             "enum": [
                 "false positive",
@@ -148,6 +156,12 @@ final readonly class Alert
                 "null"
             ],
             "description": "The reason for dismissing or closing the alert."
+        },
+        "fixed_at": {
+            "type": [
+                "null"
+            ],
+            "description": "The time that the alert was fixed in ISO 8601 format: `YYYY-MM-DDTHH:MM:SSZ`."
         },
         "html_url": {
             "type": "string",
@@ -301,10 +315,14 @@ final readonly class Alert
         },
         "state": {
             "enum": [
-                "fixed"
+                "fixed",
+                null
             ],
-            "type": "string",
-            "description": "State of a code scanning alert."
+            "type": [
+                "string",
+                "null"
+            ],
+            "description": "State of a code scanning alert. Events for alerts found outside the default branch will return a `null` value until they are dismissed or fixed."
         },
         "tool": {
             "required": [
@@ -368,7 +386,9 @@ final readonly class Alert
         "url": "https:\\/\\/example.com\\/",
         "user_view_type": "generated"
     },
+    "dismissed_comment": "generated",
     "dismissed_reason": "used in tests",
+    "fixed_at": "generated",
     "html_url": "https:\\/\\/example.com\\/",
     "instances_url": "https:\\/\\/example.com\\/",
     "most_recent_instance": {
@@ -416,19 +436,23 @@ final readonly class Alert
     /**
      * createdAt: The time that the alert was created in ISO 8601 format: `YYYY-MM-DDTHH:MM:SSZ.`
      * dismissedAt: The time that the alert was dismissed in ISO 8601 format: `YYYY-MM-DDTHH:MM:SSZ`.
+     * dismissedComment: The dismissal comment associated with the dismissal of the alert.
      * dismissedReason: The reason for dismissing or closing the alert.
+     * fixedAt: The time that the alert was fixed in ISO 8601 format: `YYYY-MM-DDTHH:MM:SSZ`.
      * htmlUrl: The GitHub URL of the alert resource.
      * number: The code scanning alert number.
-     * state: State of a code scanning alert.
+     * state: State of a code scanning alert. Events for alerts found outside the default branch will return a `null` value until they are dismissed or fixed.
      */
     public function __construct(#[MapFrom('created_at')]
     public string $createdAt, #[MapFrom('dismissed_at')]
     public string|null $dismissedAt, #[MapFrom('dismissed_by')]
-    public Schema\WebhookCodeScanningAlertFixed\Alert\DismissedBy|null $dismissedBy, #[MapFrom('dismissed_reason')]
-    public string|null $dismissedReason, #[MapFrom('html_url')]
+    public Schema\WebhookCodeScanningAlertFixed\Alert\DismissedBy|null $dismissedBy, #[MapFrom('dismissed_comment')]
+    public string|null $dismissedComment, #[MapFrom('dismissed_reason')]
+    public string|null $dismissedReason, #[MapFrom('fixed_at')]
+    public string $fixedAt, #[MapFrom('html_url')]
     public string $htmlUrl, #[MapFrom('instances_url')]
     public string|null $instancesUrl, #[MapFrom('most_recent_instance')]
-    public Schema\WebhookCodeScanningAlertFixed\Alert\MostRecentInstance|null $mostRecentInstance, public int $number, public Schema\WebhookCodeScanningAlertFixed\Alert\Rule $rule, public string $state, public Schema\WebhookCodeScanningAlertFixed\Alert\Tool $tool, public string $url,)
+    public Schema\WebhookCodeScanningAlertFixed\Alert\MostRecentInstance|null $mostRecentInstance, public int $number, public Schema\WebhookCodeScanningAlertFixed\Alert\Rule $rule, public string|null $state, public Schema\WebhookCodeScanningAlertFixed\Alert\Tool $tool, public string $url,)
     {
     }
 }

--- a/clients/GitHubEnterpriseCloud/src/Schema/WebhookCodeScanningAlertReopened.php
+++ b/clients/GitHubEnterpriseCloud/src/Schema/WebhookCodeScanningAlertReopened.php
@@ -63,12 +63,26 @@ final readonly class WebhookCodeScanningAlertReopened
                         "null"
                     ]
                 },
+                "dismissed_comment": {
+                    "maxLength": 280,
+                    "type": [
+                        "string",
+                        "null"
+                    ],
+                    "description": "The dismissal comment associated with the dismissal of the alert."
+                },
                 "dismissed_reason": {
                     "type": [
                         "string",
                         "null"
                     ],
                     "description": "The reason for dismissing or closing the alert. Can be one of: `false positive`, `won\'t fix`, and `used in tests`."
+                },
+                "fixed_at": {
+                    "type": [
+                        "null"
+                    ],
+                    "description": "The time that the alert was fixed in ISO 8601 format: `YYYY-MM-DDTHH:MM:SSZ`."
                 },
                 "html_url": {
                     "type": "string",
@@ -220,10 +234,14 @@ final readonly class WebhookCodeScanningAlertReopened
                     "enum": [
                         "open",
                         "dismissed",
-                        "fixed"
+                        "fixed",
+                        null
                     ],
-                    "type": "string",
-                    "description": "State of a code scanning alert."
+                    "type": [
+                        "string",
+                        "null"
+                    ],
+                    "description": "State of a code scanning alert. Events for alerts found outside the default branch will return a `null` value until they are dismissed or fixed."
                 },
                 "tool": {
                     "required": [
@@ -2153,7 +2171,9 @@ final readonly class WebhookCodeScanningAlertReopened
         "created_at": "1970-01-01T00:00:00+00:00",
         "dismissed_at": "generated",
         "dismissed_by": [],
+        "dismissed_comment": "generated",
         "dismissed_reason": "generated",
+        "fixed_at": "generated",
         "html_url": "https:\\/\\/example.com\\/",
         "most_recent_instance": {
             "analysis_key": "generated",

--- a/clients/GitHubEnterpriseCloud/src/Schema/WebhookCodeScanningAlertReopened/Alert.php
+++ b/clients/GitHubEnterpriseCloud/src/Schema/WebhookCodeScanningAlertReopened/Alert.php
@@ -45,12 +45,26 @@ final readonly class Alert
                 "null"
             ]
         },
+        "dismissed_comment": {
+            "maxLength": 280,
+            "type": [
+                "string",
+                "null"
+            ],
+            "description": "The dismissal comment associated with the dismissal of the alert."
+        },
         "dismissed_reason": {
             "type": [
                 "string",
                 "null"
             ],
             "description": "The reason for dismissing or closing the alert. Can be one of: `false positive`, `won\'t fix`, and `used in tests`."
+        },
+        "fixed_at": {
+            "type": [
+                "null"
+            ],
+            "description": "The time that the alert was fixed in ISO 8601 format: `YYYY-MM-DDTHH:MM:SSZ`."
         },
         "html_url": {
             "type": "string",
@@ -202,10 +216,14 @@ final readonly class Alert
             "enum": [
                 "open",
                 "dismissed",
-                "fixed"
+                "fixed",
+                null
             ],
-            "type": "string",
-            "description": "State of a code scanning alert."
+            "type": [
+                "string",
+                "null"
+            ],
+            "description": "State of a code scanning alert. Events for alerts found outside the default branch will return a `null` value until they are dismissed or fixed."
         },
         "tool": {
             "required": [
@@ -246,7 +264,9 @@ final readonly class Alert
     "created_at": "1970-01-01T00:00:00+00:00",
     "dismissed_at": "generated",
     "dismissed_by": [],
+    "dismissed_comment": "generated",
     "dismissed_reason": "generated",
+    "fixed_at": "generated",
     "html_url": "https:\\/\\/example.com\\/",
     "most_recent_instance": {
         "analysis_key": "generated",
@@ -293,18 +313,22 @@ final readonly class Alert
     /**
      * createdAt: The time that the alert was created in ISO 8601 format: `YYYY-MM-DDTHH:MM:SSZ.`
      * dismissedAt: The time that the alert was dismissed in ISO 8601 format: `YYYY-MM-DDTHH:MM:SSZ`.
+     * dismissedComment: The dismissal comment associated with the dismissal of the alert.
      * dismissedReason: The reason for dismissing or closing the alert. Can be one of: `false positive`, `won't fix`, and `used in tests`.
+     * fixedAt: The time that the alert was fixed in ISO 8601 format: `YYYY-MM-DDTHH:MM:SSZ`.
      * htmlUrl: The GitHub URL of the alert resource.
      * number: The code scanning alert number.
-     * state: State of a code scanning alert.
+     * state: State of a code scanning alert. Events for alerts found outside the default branch will return a `null` value until they are dismissed or fixed.
      */
     public function __construct(#[MapFrom('created_at')]
     public string $createdAt, #[MapFrom('dismissed_at')]
     public string|null $dismissedAt, #[MapFrom('dismissed_by')]
-    public Schema\WebhookCodeScanningAlertReopened\Alert\DismissedBy|null $dismissedBy, #[MapFrom('dismissed_reason')]
-    public string|null $dismissedReason, #[MapFrom('html_url')]
+    public Schema\WebhookCodeScanningAlertReopened\Alert\DismissedBy|null $dismissedBy, #[MapFrom('dismissed_comment')]
+    public string|null $dismissedComment, #[MapFrom('dismissed_reason')]
+    public string|null $dismissedReason, #[MapFrom('fixed_at')]
+    public string $fixedAt, #[MapFrom('html_url')]
     public string $htmlUrl, #[MapFrom('most_recent_instance')]
-    public Schema\WebhookCodeScanningAlertReopened\Alert\MostRecentInstance|null $mostRecentInstance, public int $number, public Schema\WebhookCodeScanningAlertReopened\Alert\Rule $rule, public string $state, public Schema\WebhookCodeScanningAlertReopened\Alert\Tool $tool, public string $url,)
+    public Schema\WebhookCodeScanningAlertReopened\Alert\MostRecentInstance|null $mostRecentInstance, public int $number, public Schema\WebhookCodeScanningAlertReopened\Alert\Rule $rule, public string|null $state, public Schema\WebhookCodeScanningAlertReopened\Alert\Tool $tool, public string $url,)
     {
     }
 }

--- a/clients/GitHubEnterpriseCloud/src/Schema/WebhookCodeScanningAlertReopenedByUser.php
+++ b/clients/GitHubEnterpriseCloud/src/Schema/WebhookCodeScanningAlertReopenedByUser.php
@@ -58,11 +58,25 @@ final readonly class WebhookCodeScanningAlertReopenedByUser
                         "null"
                     ]
                 },
+                "dismissed_comment": {
+                    "maxLength": 280,
+                    "type": [
+                        "string",
+                        "null"
+                    ],
+                    "description": "The dismissal comment associated with the dismissal of the alert."
+                },
                 "dismissed_reason": {
                     "type": [
                         "null"
                     ],
                     "description": "The reason for dismissing or closing the alert. Can be one of: `false positive`, `won\'t fix`, and `used in tests`."
+                },
+                "fixed_at": {
+                    "type": [
+                        "null"
+                    ],
+                    "description": "The time that the alert was fixed in ISO 8601 format: `YYYY-MM-DDTHH:MM:SSZ`."
                 },
                 "html_url": {
                     "type": "string",
@@ -185,10 +199,14 @@ final readonly class WebhookCodeScanningAlertReopenedByUser
                 "state": {
                     "enum": [
                         "open",
-                        "fixed"
+                        "fixed",
+                        null
                     ],
-                    "type": "string",
-                    "description": "State of a code scanning alert."
+                    "type": [
+                        "string",
+                        "null"
+                    ],
+                    "description": "State of a code scanning alert. Events for alerts found outside the default branch will return a `null` value until they are dismissed or fixed."
                 },
                 "tool": {
                     "required": [
@@ -2106,7 +2124,9 @@ final readonly class WebhookCodeScanningAlertReopenedByUser
         "created_at": "1970-01-01T00:00:00+00:00",
         "dismissed_at": "generated",
         "dismissed_by": "generated",
+        "dismissed_comment": "generated",
         "dismissed_reason": "generated",
+        "fixed_at": "generated",
         "html_url": "https:\\/\\/example.com\\/",
         "most_recent_instance": {
             "analysis_key": "generated",

--- a/clients/GitHubEnterpriseCloud/src/Schema/WebhookCodeScanningAlertReopenedByUser/Alert.php
+++ b/clients/GitHubEnterpriseCloud/src/Schema/WebhookCodeScanningAlertReopenedByUser/Alert.php
@@ -40,11 +40,25 @@ final readonly class Alert
                 "null"
             ]
         },
+        "dismissed_comment": {
+            "maxLength": 280,
+            "type": [
+                "string",
+                "null"
+            ],
+            "description": "The dismissal comment associated with the dismissal of the alert."
+        },
         "dismissed_reason": {
             "type": [
                 "null"
             ],
             "description": "The reason for dismissing or closing the alert. Can be one of: `false positive`, `won\'t fix`, and `used in tests`."
+        },
+        "fixed_at": {
+            "type": [
+                "null"
+            ],
+            "description": "The time that the alert was fixed in ISO 8601 format: `YYYY-MM-DDTHH:MM:SSZ`."
         },
         "html_url": {
             "type": "string",
@@ -167,10 +181,14 @@ final readonly class Alert
         "state": {
             "enum": [
                 "open",
-                "fixed"
+                "fixed",
+                null
             ],
-            "type": "string",
-            "description": "State of a code scanning alert."
+            "type": [
+                "string",
+                "null"
+            ],
+            "description": "State of a code scanning alert. Events for alerts found outside the default branch will return a `null` value until they are dismissed or fixed."
         },
         "tool": {
             "required": [
@@ -205,7 +223,9 @@ final readonly class Alert
     "created_at": "1970-01-01T00:00:00+00:00",
     "dismissed_at": "generated",
     "dismissed_by": "generated",
+    "dismissed_comment": "generated",
     "dismissed_reason": "generated",
+    "fixed_at": "generated",
     "html_url": "https:\\/\\/example.com\\/",
     "most_recent_instance": {
         "analysis_key": "generated",
@@ -246,18 +266,22 @@ final readonly class Alert
     /**
      * createdAt: The time that the alert was created in ISO 8601 format: `YYYY-MM-DDTHH:MM:SSZ.`
      * dismissedAt: The time that the alert was dismissed in ISO 8601 format: `YYYY-MM-DDTHH:MM:SSZ`.
+     * dismissedComment: The dismissal comment associated with the dismissal of the alert.
      * dismissedReason: The reason for dismissing or closing the alert. Can be one of: `false positive`, `won't fix`, and `used in tests`.
+     * fixedAt: The time that the alert was fixed in ISO 8601 format: `YYYY-MM-DDTHH:MM:SSZ`.
      * htmlUrl: The GitHub URL of the alert resource.
      * number: The code scanning alert number.
-     * state: State of a code scanning alert.
+     * state: State of a code scanning alert. Events for alerts found outside the default branch will return a `null` value until they are dismissed or fixed.
      */
     public function __construct(#[MapFrom('created_at')]
     public string $createdAt, #[MapFrom('dismissed_at')]
     public string $dismissedAt, #[MapFrom('dismissed_by')]
-    public string $dismissedBy, #[MapFrom('dismissed_reason')]
-    public string $dismissedReason, #[MapFrom('html_url')]
+    public string $dismissedBy, #[MapFrom('dismissed_comment')]
+    public string|null $dismissedComment, #[MapFrom('dismissed_reason')]
+    public string $dismissedReason, #[MapFrom('fixed_at')]
+    public string $fixedAt, #[MapFrom('html_url')]
     public string $htmlUrl, #[MapFrom('most_recent_instance')]
-    public Schema\WebhookCodeScanningAlertReopenedByUser\Alert\MostRecentInstance|null $mostRecentInstance, public int $number, public Schema\WebhookCodeScanningAlertReopenedByUser\Alert\Rule $rule, public string $state, public Schema\WebhookCodeScanningAlertReopenedByUser\Alert\Tool $tool, public string $url,)
+    public Schema\WebhookCodeScanningAlertReopenedByUser\Alert\MostRecentInstance|null $mostRecentInstance, public int $number, public Schema\WebhookCodeScanningAlertReopenedByUser\Alert\Rule $rule, public string|null $state, public Schema\WebhookCodeScanningAlertReopenedByUser\Alert\Tool $tool, public string $url,)
     {
     }
 }


### PR DESCRIPTION
Detected Schema changes:
2025-01-10 20:28:54 ERROR unable to open the rolodex file, check specification references and base path
                      ├ file: /__w/github-root/github-root/server-statistics-actions.yaml
                      └ error: open /__w/github-root/github-root/server-statistics-actions.yaml: no such file or directory
2025-01-10 20:28:54 ERROR unable to open the rolodex file, check specification references and base path
                      ├ file: /__w/github-root/github-root/server-statistics-packages.yaml
                      └ error: open /__w/github-root/github-root/server-statistics-packages.yaml: no such file or directory
2025-01-10 20:28:54 ERROR unable to open the rolodex file, check specification references and base path
                      ├ file: /__w/github-root/github-root/server-statistics-advisory-db.yaml
                      └ error: open /__w/github-root/github-root/server-statistics-advisory-db.yaml: no such file or directory
2025-01-10 20:28:57 ERROR unable to open the rolodex file, check specification references and base path
                      ├ file: /__w/github-root/github-root/server-statistics-actions.yaml
                      └ error: open /__w/github-root/github-root/server-statistics-actions.yaml: no such file or directory
2025-01-10 20:28:57 ERROR unable to open the rolodex file, check specification references and base path
                      ├ file: /__w/github-root/github-root/server-statistics-packages.yaml
                      └ error: open /__w/github-root/github-root/server-statistics-packages.yaml: no such file or directory
2025-01-10 20:28:57 ERROR unable to open the rolodex file, check specification references and base path
                      ├ file: /__w/github-root/github-root/server-statistics-advisory-db.yaml
                      └ error: open /__w/github-root/github-root/server-statistics-advisory-db.yaml: no such file or directory
ERROR: component `server-statistics-actions.yaml` does not exist in the specification
ERROR: component `server-statistics-packages.yaml` does not exist in the specification
ERROR: component `server-statistics-advisory-db.yaml` does not exist in the specification
ERROR: cannot resolve reference `server-statistics-actions.yaml`, it's missing:  [213061:11]
ERROR: cannot resolve reference `server-statistics-packages.yaml`, it's missing:  [213063:11]
ERROR: cannot resolve reference `server-statistics-advisory-db.yaml`, it's missing:  [213065:11]
ERROR: component `server-statistics-actions.yaml` does not exist in the specification
ERROR: component `server-statistics-packages.yaml` does not exist in the specification
ERROR: component `server-statistics-advisory-db.yaml` does not exist in the specification
ERROR: cannot resolve reference `server-statistics-actions.yaml`, it's missing:  [213002:11]
ERROR: cannot resolve reference `server-statistics-packages.yaml`, it's missing:  [213004:11]
ERROR: cannot resolve reference `server-statistics-advisory-db.yaml`, it's missing:  [213006:11]
