### PR TITLE
[GitHubEnterprise-3.14] Update to 1.1.4-f5ae341048327f8fa2b6a1ba017066cc from 1.1.4-dc977c8003154234e7a787ec7b8ad5db

### DIFF
--- a/clients/GitHubEnterprise-3.14/etc/openapi-client-generator.state
+++ b/clients/GitHubEnterprise-3.14/etc/openapi-client-generator.state
@@ -1,5 +1,5 @@
 {
-    "specHash": "dc977c8003154234e7a787ec7b8ad5db",
+    "specHash": "f5ae341048327f8fa2b6a1ba017066cc",
     "generatedFiles": {
         "files": [
             {
@@ -13516,7 +13516,7 @@
             },
             {
                 "name": ".\/clients\/GitHubEnterprise-3.14\/etc\/..\/\/src\/\/Schema\/Announcement.php",
-                "hash": "43d88c2fe6d9b323473405dbb6d7cbe7"
+                "hash": "fc94b9b02ef56f864c859e9d58d3ce45"
             },
             {
                 "name": ".\/clients\/GitHubEnterprise-3.14\/etc\/..\/\/src\/\/Schema\/LicenseInfo.php",
@@ -27464,7 +27464,7 @@
             },
             {
                 "name": ".\/clients\/GitHubEnterprise-3.14\/etc\/..\/\/src\/\/Operation\/EnterpriseAdmin.php",
-                "hash": "8e5ed19636edd3f61c268f23d3dba92d"
+                "hash": "3969d0c96e854589ccfd64812d38dcba"
             },
             {
                 "name": ".\/clients\/GitHubEnterprise-3.14\/etc\/..\/\/src\/\/Operation\/SecurityAdvisories.php",
@@ -28048,7 +28048,7 @@
             },
             {
                 "name": ".\/clients\/GitHubEnterprise-3.14\/etc\/..\/\/src\/\/Internal\/Hydrator\/Operation\/Enterprise\/Announcement.php",
-                "hash": "2031eff3f5c8d7209048e852b5c84031"
+                "hash": "5e98612b79dbbc66f8c8e936476d0875"
             },
             {
                 "name": ".\/clients\/GitHubEnterprise-3.14\/etc\/..\/\/src\/\/Internal\/Hydrator\/Operation\/Enterprise\/Settings\/License.php",

--- a/clients/GitHubEnterprise-3.14/src/Internal/Hydrator/Operation/Enterprise/Announcement.php
+++ b/clients/GitHubEnterprise-3.14/src/Internal/Hydrator/Operation/Enterprise/Announcement.php
@@ -68,6 +68,17 @@ class Announcement implements ObjectMapper
             $properties['expiresAt'] = $value;
 
             after_expiresAt:
+
+            $value = $payload['user_dismissible'] ?? null;
+
+            if ($value === null) {
+                $properties['userDismissible'] = null;
+                goto after_userDismissible;
+            }
+
+            $properties['userDismissible'] = $value;
+
+            after_userDismissible:
         } catch (Throwable $exception) {
             throw UnableToHydrateObject::dueToError('ApiClients\Client\GitHubEnterprise\Schema\Announcement', $exception, stack: $this->hydrationStack);
         }
@@ -197,6 +208,14 @@ class Announcement implements ObjectMapper
         }
 
         after_expiresAt:        $result['expires_at'] = $expiresAt;
+
+        $userDismissible = $object->userDismissible;
+
+        if ($userDismissible === null) {
+            goto after_userDismissible;
+        }
+
+        after_userDismissible:        $result['user_dismissible'] = $userDismissible;
 
         return $result;
     }

--- a/clients/GitHubEnterprise-3.14/src/Schema/Announcement.php
+++ b/clients/GitHubEnterprise-3.14/src/Schema/Announcement.php
@@ -35,6 +35,17 @@ final readonly class Announcement
             "examples": [
                 "\\"2021-01-01T00:00:00.000-07:00\\""
             ]
+        },
+        "user_dismissible": {
+            "type": [
+                "boolean",
+                "null"
+            ],
+            "description": "Whether an announcement can be dismissed by the user.",
+            "default": false,
+            "examples": [
+                false
+            ]
         }
     },
     "description": "Enterprise global announcement"
@@ -43,15 +54,18 @@ final readonly class Announcement
     public const SCHEMA_DESCRIPTION  = 'Enterprise global announcement';
     public const SCHEMA_EXAMPLE_DATA = '{
     "announcement": "Very **important** announcement about _something_.",
-    "expires_at": "\\"2021-01-01T00:00:00.000-07:00\\""
+    "expires_at": "\\"2021-01-01T00:00:00.000-07:00\\"",
+    "user_dismissible": false
 }';
 
     /**
      * announcement: The announcement text in GitHub Flavored Markdown. For more information about GitHub Flavored Markdown, see "[Basic writing and formatting syntax](https://docs.github.com/enterprise-server@3.14/github/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax)."
      * expiresAt: The time at which the announcement expires. This is a timestamp in [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) format: `YYYY-MM-DDTHH:MM:SSZ`. To set an announcement that never expires, omit this parameter, set it to `null`, or set it to an empty string.
+     * userDismissible: Whether an announcement can be dismissed by the user.
      */
     public function __construct(public string|null $announcement, #[MapFrom('expires_at')]
-    public string|null $expiresAt,)
+    public string|null $expiresAt, #[MapFrom('user_dismissible')]
+    public bool|null $userDismissible,)
     {
     }
 }


### PR DESCRIPTION
Detected Schema changes:



```
├─┬Paths
│ └─┬/repos/{owner}/{repo}/issues/{issue_number}/reactions
│   └─┬POST
│     └─┬Extensions
│       └──[🔀] x-github (33690:9)
└─┬Components
  └─┬announcement
    └──[➖] properties (69150:9)❌ 

```

| Document Element | Total Changes | Breaking Changes |
|------------------|---------------|------------------|
| paths            | 1             | 0                |
| components       | 1             | 1                |

Date: 02/12/25 | Commit: New: etc/specs/GitHubEnterprise-3.14/previous.spec.yaml, Original: etc/specs/GitHubEnterprise-3.14/current.spec.yaml

- ❌ **BREAKING Changes**: _1_ out of _2_
- **Modifications**: _1_
- **Removals**: _1_
- **Breaking Removals**: _1_

ERROR: breaking changes discovered
