### PR TITLE
[GitHubEnterpriseCloud] Update to 1.1.4-16de2a81f1c35833bd49594dda36d269 from 1.1.4-1a921a530f820efa033dc420e6e40c95

### DIFF
--- a/clients/GitHubEnterpriseCloud/etc/openapi-client-generator.state
+++ b/clients/GitHubEnterpriseCloud/etc/openapi-client-generator.state
@@ -1,5 +1,5 @@
 {
-    "specHash": "1a921a530f820efa033dc420e6e40c95",
+    "specHash": "16de2a81f1c35833bd49594dda36d269",
     "generatedFiles": {
         "files": [
             {
@@ -788,7 +788,7 @@
             },
             {
                 "name": ".\/clients\/GitHubEnterpriseCloud\/etc\/..\/\/src\/\/Schema\/Artifact.php",
-                "hash": "b1ebe11cdce02325b812861ad423f569"
+                "hash": "0ae5e956f39d3359295027e0b1030f7a"
             },
             {
                 "name": ".\/clients\/GitHubEnterpriseCloud\/etc\/..\/\/src\/\/Schema\/ActionsCacheList.php",
@@ -5052,7 +5052,7 @@
             },
             {
                 "name": ".\/clients\/GitHubEnterpriseCloud\/etc\/..\/\/src\/\/Schema\/Operations\/Actions\/ListArtifactsForRepo\/Response\/ApplicationJson\/Ok.php",
-                "hash": "2f542021b8a055ce9cf0ce3bfa87b2ca"
+                "hash": "1a007cc9edb090f1efec8a2a43707b37"
             },
             {
                 "name": ".\/clients\/GitHubEnterpriseCloud\/etc\/..\/\/src\/\/Schema\/Actions\/ReRunJobForWorkflowRun\/Request\/ApplicationJson.php",
@@ -11731,16 +11731,12 @@
                 "hash": "2aa45263671135fe8fdd8183d6d9c785"
             },
             {
-                "name": ".\/clients\/GitHubEnterpriseCloud\/etc\/..\/\/src\/\/Schema\/AliasAbstract\/Tiet1A91B16F\/TietBF38476A\/Tiet7587BB22\/TietE0507C4B.php",
-                "hash": "a7de1c0500dc6b4509b2089361c75a2f"
-            },
-            {
                 "name": ".\/clients\/GitHubEnterpriseCloud\/etc\/..\/\/src\/\/Schema\/Operations\/Actions\/ListWorkflowRunArtifacts\/Response\/ApplicationJson\/Ok.php",
-                "hash": "4dd33c1b2998d67841406425f8cffb8d"
+                "hash": "70bfc1bb85d64fc09be7769e3c978f48"
             },
             {
                 "name": ".\/clients\/GitHubEnterpriseCloud\/etc\/..\/\/src\/\/Schema\/Operations\/Actions\/ListWorkflowRunArtifacts\/Response\/ApplicationJson\/Ok\/Application\/Json.php",
-                "hash": "16db918de3600b04499127ad64de7d20"
+                "hash": "fc8a1bef3937dae377a263b645e55e2a"
             },
             {
                 "name": ".\/clients\/GitHubEnterpriseCloud\/etc\/..\/\/src\/\/Schema\/AliasAbstract\/TietD2A75913\/Tiet0388E4E1\/TietCC684AA9\/Tiet46754F39.php",
@@ -27560,7 +27556,7 @@
             },
             {
                 "name": ".\/clients\/GitHubEnterpriseCloud\/etc\/..\/\/src\/\/Internal\/Hydrator\/Operation\/Repos\/Owner\/Repo\/Actions\/Artifacts\/ArtifactId.php",
-                "hash": "f02fcb061692e8e679d309661c113ef3"
+                "hash": "0b68d75f06a35dcbe4445acee9828f78"
             },
             {
                 "name": ".\/clients\/GitHubEnterpriseCloud\/etc\/..\/\/src\/\/Internal\/Hydrator\/Operation\/Repos\/Owner\/Repo\/Actions\/Artifacts\/ArtifactId\/ArchiveFormat.php",
@@ -35057,6 +35053,10 @@
             {
                 "name": ".\/clients\/GitHubEnterpriseCloud\/etc\/..\/\/src\/\/Schema\/CopilotOrganizationSeatBreakdown.php",
                 "hash": "ae9b75aa40c504807916598c96e7569a"
+            },
+            {
+                "name": ".\/clients\/GitHubEnterpriseCloud\/etc\/..\/\/src\/\/Schema\/AliasAbstract\/TietCF22D054\/Tiet02EB2DC0\/Tiet6BB5072C\/Tiet3B86314A.php",
+                "hash": "aa4e99cc47f789f858586329ecfca850"
             }
         ]
     },

--- a/clients/GitHubEnterpriseCloud/src/Internal/Hydrator/Operation/Repos/Owner/Repo/Actions/Artifacts/ArtifactId.php
+++ b/clients/GitHubEnterpriseCloud/src/Internal/Hydrator/Operation/Repos/Owner/Repo/Actions/Artifacts/ArtifactId.php
@@ -162,6 +162,17 @@ class ArtifactId implements ObjectMapper
 
             after_updatedAt:
 
+            $value = $payload['digest'] ?? null;
+
+            if ($value === null) {
+                $properties['digest'] = null;
+                goto after_digest;
+            }
+
+            $properties['digest'] = $value;
+
+            after_digest:
+
             $value = $payload['workflow_run'] ?? null;
 
             if ($value === null) {
@@ -414,6 +425,14 @@ class ArtifactId implements ObjectMapper
         }
 
         after_updatedAt:        $result['updated_at'] = $updatedAt;
+
+        $digest = $object->digest;
+
+        if ($digest === null) {
+            goto after_digest;
+        }
+
+        after_digest:        $result['digest'] = $digest;
 
         $workflowRun = $object->workflowRun;
 

--- a/clients/GitHubEnterpriseCloud/src/Schema/AliasAbstract/TietCF22D054/Tiet02EB2DC0/Tiet6BB5072C/Tiet3B86314A.php
+++ b/clients/GitHubEnterpriseCloud/src/Schema/AliasAbstract/TietCF22D054/Tiet02EB2DC0/Tiet6BB5072C/Tiet3B86314A.php
@@ -2,11 +2,11 @@
 
 declare(strict_types=1);
 
-namespace ApiClients\Client\GitHubEnterpriseCloud\Schema\AliasAbstract\Tiet1A91B16F\TietBF38476A\Tiet7587BB22;
+namespace ApiClients\Client\GitHubEnterpriseCloud\Schema\AliasAbstract\TietCF22D054\Tiet02EB2DC0\Tiet6BB5072C;
 
 use EventSauce\ObjectHydrator\MapFrom;
 
-abstract readonly class TietE0507C4B
+abstract readonly class Tiet3B86314A
 {
     public const SCHEMA_JSON         = '{
     "required": [
@@ -99,6 +99,16 @@ abstract readonly class TietE0507C4B
                         ],
                         "format": "date-time"
                     },
+                    "digest": {
+                        "type": [
+                            "string",
+                            "null"
+                        ],
+                        "description": "The SHA256 digest of the artifact. This field will only be populated on artifacts uploaded with upload-artifact v4 or newer. For older versions, this field will be null.",
+                        "examples": [
+                            "sha256:cfc3236bdad15b5898bca8408945c9e19e1917da8704adc20eaa618444290a8c"
+                        ]
+                    },
                     "workflow_run": {
                         "type": [
                             "object",
@@ -159,6 +169,7 @@ abstract readonly class TietE0507C4B
             "created_at": "1970-01-01T00:00:00+00:00",
             "expires_at": "1970-01-01T00:00:00+00:00",
             "updated_at": "1970-01-01T00:00:00+00:00",
+            "digest": "sha256:cfc3236bdad15b5898bca8408945c9e19e1917da8704adc20eaa618444290a8c",
             "workflow_run": {
                 "id": 10,
                 "repository_id": 42,
@@ -178,6 +189,7 @@ abstract readonly class TietE0507C4B
             "created_at": "1970-01-01T00:00:00+00:00",
             "expires_at": "1970-01-01T00:00:00+00:00",
             "updated_at": "1970-01-01T00:00:00+00:00",
+            "digest": "sha256:cfc3236bdad15b5898bca8408945c9e19e1917da8704adc20eaa618444290a8c",
             "workflow_run": {
                 "id": 10,
                 "repository_id": 42,

--- a/clients/GitHubEnterpriseCloud/src/Schema/Artifact.php
+++ b/clients/GitHubEnterpriseCloud/src/Schema/Artifact.php
@@ -88,6 +88,16 @@ final readonly class Artifact
             ],
             "format": "date-time"
         },
+        "digest": {
+            "type": [
+                "string",
+                "null"
+            ],
+            "description": "The SHA256 digest of the artifact. This field will only be populated on artifacts uploaded with upload-artifact v4 or newer. For older versions, this field will be null.",
+            "examples": [
+                "sha256:cfc3236bdad15b5898bca8408945c9e19e1917da8704adc20eaa618444290a8c"
+            ]
+        },
         "workflow_run": {
             "type": [
                 "object",
@@ -142,6 +152,7 @@ final readonly class Artifact
     "created_at": "1970-01-01T00:00:00+00:00",
     "expires_at": "1970-01-01T00:00:00+00:00",
     "updated_at": "1970-01-01T00:00:00+00:00",
+    "digest": "sha256:cfc3236bdad15b5898bca8408945c9e19e1917da8704adc20eaa618444290a8c",
     "workflow_run": {
         "id": 10,
         "repository_id": 42,
@@ -155,6 +166,7 @@ final readonly class Artifact
      * name: The name of the artifact.
      * sizeInBytes: The size in bytes of the artifact.
      * expired: Whether or not the artifact has expired.
+     * digest: The SHA256 digest of the artifact. This field will only be populated on artifacts uploaded with upload-artifact v4 or newer. For older versions, this field will be null.
      */
     public function __construct(public int $id, #[MapFrom('node_id')]
     public string $nodeId, public string $name, #[MapFrom('size_in_bytes')]
@@ -162,7 +174,7 @@ final readonly class Artifact
     public string $archiveDownloadUrl, public bool $expired, #[MapFrom('created_at')]
     public string|null $createdAt, #[MapFrom('expires_at')]
     public string|null $expiresAt, #[MapFrom('updated_at')]
-    public string|null $updatedAt, #[MapFrom('workflow_run')]
+    public string|null $updatedAt, public string|null $digest, #[MapFrom('workflow_run')]
     public Schema\Artifact\WorkflowRun|null $workflowRun,)
     {
     }

--- a/clients/GitHubEnterpriseCloud/src/Schema/Operations/Actions/ListArtifactsForRepo/Response/ApplicationJson/Ok.php
+++ b/clients/GitHubEnterpriseCloud/src/Schema/Operations/Actions/ListArtifactsForRepo/Response/ApplicationJson/Ok.php
@@ -6,6 +6,6 @@ namespace ApiClients\Client\GitHubEnterpriseCloud\Schema\Operations\Actions\List
 
 use ApiClients\Client\GitHubEnterpriseCloud\Schema;
 
-final readonly class Ok extends Schema\AliasAbstract\Tiet1A91B16F\TietBF38476A\Tiet7587BB22\TietE0507C4B
+final readonly class Ok extends Schema\AliasAbstract\TietCF22D054\Tiet02EB2DC0\Tiet6BB5072C\Tiet3B86314A
 {
 }

--- a/clients/GitHubEnterpriseCloud/src/Schema/Operations/Actions/ListWorkflowRunArtifacts/Response/ApplicationJson/Ok.php
+++ b/clients/GitHubEnterpriseCloud/src/Schema/Operations/Actions/ListWorkflowRunArtifacts/Response/ApplicationJson/Ok.php
@@ -6,6 +6,6 @@ namespace ApiClients\Client\GitHubEnterpriseCloud\Schema\Operations\Actions\List
 
 use ApiClients\Client\GitHubEnterpriseCloud\Schema;
 
-final readonly class Ok extends Schema\AliasAbstract\Tiet1A91B16F\TietBF38476A\Tiet7587BB22\TietE0507C4B
+final readonly class Ok extends Schema\AliasAbstract\TietCF22D054\Tiet02EB2DC0\Tiet6BB5072C\Tiet3B86314A
 {
 }

--- a/clients/GitHubEnterpriseCloud/src/Schema/Operations/Actions/ListWorkflowRunArtifacts/Response/ApplicationJson/Ok/Application/Json.php
+++ b/clients/GitHubEnterpriseCloud/src/Schema/Operations/Actions/ListWorkflowRunArtifacts/Response/ApplicationJson/Ok/Application/Json.php
@@ -6,6 +6,6 @@ namespace ApiClients\Client\GitHubEnterpriseCloud\Schema\Operations\Actions\List
 
 use ApiClients\Client\GitHubEnterpriseCloud\Schema;
 
-final readonly class Json extends Schema\AliasAbstract\Tiet1A91B16F\TietBF38476A\Tiet7587BB22\TietE0507C4B
+final readonly class Json extends Schema\AliasAbstract\TietCF22D054\Tiet02EB2DC0\Tiet6BB5072C\Tiet3B86314A
 {
 }


### PR DESCRIPTION
Detected Schema changes:
2025-02-21 20:28:08 ERROR unable to open the rolodex file, check specification references and base path
                      ├ file: /__w/github-root/github-root/server-statistics-actions.yaml
                      └ error: open /__w/github-root/github-root/server-statistics-actions.yaml: no such file or directory
2025-02-21 20:28:08 ERROR unable to open the rolodex file, check specification references and base path
                      ├ file: /__w/github-root/github-root/server-statistics-packages.yaml
                      └ error: open /__w/github-root/github-root/server-statistics-packages.yaml: no such file or directory
2025-02-21 20:28:08 ERROR unable to open the rolodex file, check specification references and base path
                      ├ file: /__w/github-root/github-root/server-statistics-advisory-db.yaml
                      └ error: open /__w/github-root/github-root/server-statistics-advisory-db.yaml: no such file or directory
2025-02-21 20:28:10 ERROR unable to open the rolodex file, check specification references and base path
                      ├ file: /__w/github-root/github-root/server-statistics-actions.yaml
                      └ error: open /__w/github-root/github-root/server-statistics-actions.yaml: no such file or directory
2025-02-21 20:28:10 ERROR unable to open the rolodex file, check specification references and base path
                      ├ error: open /__w/github-root/github-root/server-statistics-packages.yaml: no such file or directory
                      └ file: /__w/github-root/github-root/server-statistics-packages.yaml
2025-02-21 20:28:10 ERROR unable to open the rolodex file, check specification references and base path
                      ├ error: open /__w/github-root/github-root/server-statistics-advisory-db.yaml: no such file or directory
                      └ file: /__w/github-root/github-root/server-statistics-advisory-db.yaml
ERROR: component `server-statistics-actions.yaml` does not exist in the specification
ERROR: component `server-statistics-packages.yaml` does not exist in the specification
ERROR: component `server-statistics-advisory-db.yaml` does not exist in the specification
ERROR: cannot resolve reference `server-statistics-actions.yaml`, it's missing: $.['server-statistics-actions.yaml'] [215510:11]
ERROR: cannot resolve reference `server-statistics-packages.yaml`, it's missing: $.['server-statistics-packages.yaml'] [215512:11]
ERROR: cannot resolve reference `server-statistics-advisory-db.yaml`, it's missing: $.['server-statistics-advisory-db.yaml'] [215514:11]
ERROR: component `server-statistics-actions.yaml` does not exist in the specification
ERROR: component `server-statistics-packages.yaml` does not exist in the specification
ERROR: component `server-statistics-advisory-db.yaml` does not exist in the specification
ERROR: cannot resolve reference `server-statistics-actions.yaml`, it's missing: $.['server-statistics-actions.yaml'] [215501:11]
ERROR: cannot resolve reference `server-statistics-packages.yaml`, it's missing: $.['server-statistics-packages.yaml'] [215503:11]
ERROR: cannot resolve reference `server-statistics-advisory-db.yaml`, it's missing: $.['server-statistics-advisory-db.yaml'] [215505:11]
