### PR TITLE
[GitHubEnterpriseCloud] Update to 1.1.4-deaa86f358a396abef8aff5fbc91b653 from 1.1.4-ae847df328a461c8fd1824d1414a9038

### DIFF
--- a/clients/GitHubEnterpriseCloud/etc/openapi-client-generator.state
+++ b/clients/GitHubEnterpriseCloud/etc/openapi-client-generator.state
@@ -1,5 +1,5 @@
 {
-    "specHash": "ae847df328a461c8fd1824d1414a9038",
+    "specHash": "deaa86f358a396abef8aff5fbc91b653",
     "generatedFiles": {
         "files": [
             {
@@ -336,7 +336,7 @@
             },
             {
                 "name": ".\/clients\/GitHubEnterpriseCloud\/etc\/..\/\/src\/\/Schema\/DependabotAlertWithRepository.php",
-                "hash": "75ba51785c304f6597baa599353c02a9"
+                "hash": "8d48c8c5a31fa7c04687a6bd24b0cb73"
             },
             {
                 "name": ".\/clients\/GitHubEnterpriseCloud\/etc\/..\/\/src\/\/Schema\/GetLicenseSyncStatus.php",
@@ -1112,7 +1112,7 @@
             },
             {
                 "name": ".\/clients\/GitHubEnterpriseCloud\/etc\/..\/\/src\/\/Schema\/DependabotAlert.php",
-                "hash": "8c8da252bd4addab6fad4e3bdbfe00c4"
+                "hash": "639266358f356d96627cda010967e884"
             },
             {
                 "name": ".\/clients\/GitHubEnterpriseCloud\/etc\/..\/\/src\/\/Schema\/DependabotSecret.php",
@@ -1776,31 +1776,31 @@
             },
             {
                 "name": ".\/clients\/GitHubEnterpriseCloud\/etc\/..\/\/src\/\/Schema\/WebhookDependabotAlertAutoDismissed.php",
-                "hash": "b8a1c59729ed0dbb67edccc33e35da77"
+                "hash": "1bc7605ca968b3289d16ae756bd910d5"
             },
             {
                 "name": ".\/clients\/GitHubEnterpriseCloud\/etc\/..\/\/src\/\/Schema\/WebhookDependabotAlertAutoReopened.php",
-                "hash": "a08820d4fa1477518a135ebb97763d01"
+                "hash": "63842e290fbb219dd079d973fd1939b1"
             },
             {
                 "name": ".\/clients\/GitHubEnterpriseCloud\/etc\/..\/\/src\/\/Schema\/WebhookDependabotAlertCreated.php",
-                "hash": "f321458ef7001f8b1fb94553336d0819"
+                "hash": "36ceef11153547cf7d7c51981d365612"
             },
             {
                 "name": ".\/clients\/GitHubEnterpriseCloud\/etc\/..\/\/src\/\/Schema\/WebhookDependabotAlertDismissed.php",
-                "hash": "03c833e4fd50dc18d41178cec9bfd2d2"
+                "hash": "0fd63fd4117f91908b43236be0e32d4d"
             },
             {
                 "name": ".\/clients\/GitHubEnterpriseCloud\/etc\/..\/\/src\/\/Schema\/WebhookDependabotAlertFixed.php",
-                "hash": "b2547107a536c0b2c7eb1dc83baa9cfd"
+                "hash": "209320230e754a6c35d0404e2806d1c9"
             },
             {
                 "name": ".\/clients\/GitHubEnterpriseCloud\/etc\/..\/\/src\/\/Schema\/WebhookDependabotAlertReintroduced.php",
-                "hash": "5fce21d251634089a808ea7eff2c17a0"
+                "hash": "e31c69837b58610b77c54b9c994fe70f"
             },
             {
                 "name": ".\/clients\/GitHubEnterpriseCloud\/etc\/..\/\/src\/\/Schema\/WebhookDependabotAlertReopened.php",
-                "hash": "f6bea97ebbc6e7b18629458cb5b5c3db"
+                "hash": "9a879a460373a0d552ea6a36b33bb97b"
             },
             {
                 "name": ".\/clients\/GitHubEnterpriseCloud\/etc\/..\/\/src\/\/Schema\/WebhookDeployKeyCreated.php",
@@ -2764,7 +2764,7 @@
             },
             {
                 "name": ".\/clients\/GitHubEnterpriseCloud\/etc\/..\/\/src\/\/Schema\/DependabotAlertWithRepository\/Dependency.php",
-                "hash": "205f009b3eb302e7eea62456220cff64"
+                "hash": "68ae76d3909c8c1a8eee1db803d11476"
             },
             {
                 "name": ".\/clients\/GitHubEnterpriseCloud\/etc\/..\/\/src\/\/Schema\/GetLicenseSyncStatus\/ServerInstances.php",
@@ -5864,7 +5864,7 @@
             },
             {
                 "name": ".\/clients\/GitHubEnterpriseCloud\/etc\/..\/\/src\/\/Operation\/Meta.php",
-                "hash": "e68d3599a18b8dc4d594be6d17725d03"
+                "hash": "73ca63dcc41b4c882cf1f6c8c8e12e2d"
             },
             {
                 "name": ".\/clients\/GitHubEnterpriseCloud\/etc\/..\/\/src\/\/Operation\/Apps.php",
@@ -5932,7 +5932,7 @@
             },
             {
                 "name": ".\/clients\/GitHubEnterpriseCloud\/etc\/..\/\/src\/\/Operation\/Orgs.php",
-                "hash": "3119bcc18565a6c0afcd504762de994e"
+                "hash": "b3f15f630c7b75c52149e4861ee03724"
             },
             {
                 "name": ".\/clients\/GitHubEnterpriseCloud\/etc\/..\/\/src\/\/Operation\/Oidc.php",
@@ -5964,7 +5964,7 @@
             },
             {
                 "name": ".\/clients\/GitHubEnterpriseCloud\/etc\/..\/\/src\/\/Operation\/Repos.php",
-                "hash": "50c9958b2092d8e2f38da03a9ffaa5cf"
+                "hash": "c619cc54ecb935adcec39c4e703edf2b"
             },
             {
                 "name": ".\/clients\/GitHubEnterpriseCloud\/etc\/..\/\/src\/\/Operation\/Reactions.php",
@@ -5980,7 +5980,7 @@
             },
             {
                 "name": ".\/clients\/GitHubEnterpriseCloud\/etc\/..\/\/src\/\/Operation\/DependencyGraph.php",
-                "hash": "563474966ff06eba9802aa80ec49da1d"
+                "hash": "76fdaf36f005de7f4eb4b734558ef64c"
             },
             {
                 "name": ".\/clients\/GitHubEnterpriseCloud\/etc\/..\/\/src\/\/Operation\/Git.php",
@@ -6000,11 +6000,11 @@
             },
             {
                 "name": ".\/clients\/GitHubEnterpriseCloud\/etc\/..\/\/src\/\/Operation\/Search.php",
-                "hash": "b29aae60168b42088fd75b4b875fef48"
+                "hash": "207c460950ce2fdddf15b924c9e54c8e"
             },
             {
                 "name": ".\/clients\/GitHubEnterpriseCloud\/etc\/..\/\/src\/\/Operation\/Users.php",
-                "hash": "abc7b2787f42001de1af5078176e1530"
+                "hash": "cd145918d80f5d8f07b9617c2485a292"
             },
             {
                 "name": ".\/clients\/GitHubEnterpriseCloud\/etc\/..\/\/src\/\/Operations.php",
@@ -6335,12 +6335,8 @@
                 "hash": "c8261186a1d512e54143498b950fb8df"
             },
             {
-                "name": ".\/clients\/GitHubEnterpriseCloud\/etc\/..\/\/src\/\/Schema\/AliasAbstract\/Tiet2BF61F22\/TietD40E495C\/TietD2DCD6B6\/Tiet9D8D9B32.php",
-                "hash": "5646b100621056d65fed8a01c13c835e"
-            },
-            {
                 "name": ".\/clients\/GitHubEnterpriseCloud\/etc\/..\/\/src\/\/Schema\/DependabotAlert\/Dependency.php",
-                "hash": "6da605b1015c3579582a0aaa1c52a402"
+                "hash": "3bb756f9f567a5e725d691fd7f80664f"
             },
             {
                 "name": ".\/clients\/GitHubEnterpriseCloud\/etc\/..\/\/src\/\/Schema\/AliasAbstract\/Tiet0B6D5155\/Tiet9712C7F9\/Tiet6BF72693\/Tiet5B5B145C.php",
@@ -27968,7 +27964,7 @@
             },
             {
                 "name": ".\/clients\/GitHubEnterpriseCloud\/etc\/..\/\/src\/\/Internal\/Hydrator\/Operation\/Repos\/Owner\/Repo\/Dependabot\/Alerts\/AlertNumber.php",
-                "hash": "97af5dd2dbcdb33d67258d99a60ce1cb"
+                "hash": "c025ca120a940b2e9b04f8bb8e96051d"
             },
             {
                 "name": ".\/clients\/GitHubEnterpriseCloud\/etc\/..\/\/src\/\/Internal\/Hydrator\/Operation\/Repos\/Owner\/Repo\/Dependabot\/Secrets.php",
@@ -30032,7 +30028,7 @@
             },
             {
                 "name": ".\/clients\/GitHubEnterpriseCloud\/etc\/..\/\/src\/\/Internal\/Hydrator\/WebHook\/DependabotAlert.php",
-                "hash": "a20d8f34df0884f2940f9c2c1aef5610"
+                "hash": "75eec39d40a555f6c9e8533031eff044"
             },
             {
                 "name": ".\/clients\/GitHubEnterpriseCloud\/etc\/..\/\/src\/\/Internal\/Hydrator\/WebHook\/DeployKey.php",
@@ -33912,7 +33908,7 @@
             },
             {
                 "name": ".\/clients\/GitHubEnterpriseCloud\/etc\/..\/\/src\/\/Schema\/CodeSecurity\/CreateConfigurationForEnterprise\/Request\/ApplicationJson.php",
-                "hash": "5a99e534007ad84407aec08f264b577f"
+                "hash": "947509c6277d7593036c2a2409178376"
             },
             {
                 "name": ".\/clients\/GitHubEnterpriseCloud\/etc\/..\/\/src\/\/Schema\/AliasAbstract\/Tiet8DAAD835\/Tiet93FE8D1C\/TietAC26D50C\/Tiet27D4E07F.php",
@@ -33924,7 +33920,7 @@
             },
             {
                 "name": ".\/clients\/GitHubEnterpriseCloud\/etc\/..\/\/src\/\/Schema\/CodeSecurity\/UpdateEnterpriseConfiguration\/Request\/ApplicationJson.php",
-                "hash": "9aa1030b46fd9713cbda9e8318603275"
+                "hash": "f2be353a5dc26f0d35886cc2604f01cc"
             },
             {
                 "name": ".\/clients\/GitHubEnterpriseCloud\/etc\/..\/\/src\/\/Schema\/CodeSecurity\/AttachEnterpriseConfiguration\/Request\/ApplicationJson.php",
@@ -35221,6 +35217,10 @@
             {
                 "name": ".\/clients\/GitHubEnterpriseCloud\/etc\/..\/\/src\/\/Internal\/Hydrator\/WebHook\/ExemptionRequestSecretScanningClosure.php",
                 "hash": "b1ffae6fd762fd0812be29cb897b0032"
+            },
+            {
+                "name": ".\/clients\/GitHubEnterpriseCloud\/etc\/..\/\/src\/\/Schema\/AliasAbstract\/Tiet1DA73592\/TietBB556EE9\/Tiet519FED8E\/TietFC41A28A.php",
+                "hash": "99f644b6d3dea8df2c1bc2aa5024e9d6"
             }
         ]
     },

--- a/clients/GitHubEnterpriseCloud/src/Internal/Hydrator/Operation/Repos/Owner/Repo/Dependabot/Alerts/AlertNumber.php
+++ b/clients/GitHubEnterpriseCloud/src/Internal/Hydrator/Operation/Repos/Owner/Repo/Dependabot/Alerts/AlertNumber.php
@@ -339,6 +339,17 @@ class AlertNumber implements ObjectMapper
             $properties['scope'] = $value;
 
             after_scope:
+
+            $value = $payload['relationship'] ?? null;
+
+            if ($value === null) {
+                $properties['relationship'] = null;
+                goto after_relationship;
+            }
+
+            $properties['relationship'] = $value;
+
+            after_relationship:
         } catch (Throwable $exception) {
             throw UnableToHydrateObject::dueToError('ApiClients\Client\GitHubEnterpriseCloud\Schema\DependabotAlert\Dependency', $exception, stack: $this->hydrationStack);
         }
@@ -1625,6 +1636,14 @@ class AlertNumber implements ObjectMapper
         }
 
         after_scope:        $result['scope'] = $scope;
+
+        $relationship = $object->relationship;
+
+        if ($relationship === null) {
+            goto after_relationship;
+        }
+
+        after_relationship:        $result['relationship'] = $relationship;
 
         return $result;
     }

--- a/clients/GitHubEnterpriseCloud/src/Internal/Hydrator/WebHook/DependabotAlert.php
+++ b/clients/GitHubEnterpriseCloud/src/Internal/Hydrator/WebHook/DependabotAlert.php
@@ -515,6 +515,17 @@ class DependabotAlert implements ObjectMapper
             $properties['scope'] = $value;
 
             after_scope:
+
+            $value = $payload['relationship'] ?? null;
+
+            if ($value === null) {
+                $properties['relationship'] = null;
+                goto after_relationship;
+            }
+
+            $properties['relationship'] = $value;
+
+            after_relationship:
         } catch (Throwable $exception) {
             throw UnableToHydrateObject::dueToError('ApiClients\Client\GitHubEnterpriseCloud\Schema\DependabotAlert\Dependency', $exception, stack: $this->hydrationStack);
         }
@@ -5522,6 +5533,14 @@ class DependabotAlert implements ObjectMapper
         }
 
         after_scope:        $result['scope'] = $scope;
+
+        $relationship = $object->relationship;
+
+        if ($relationship === null) {
+            goto after_relationship;
+        }
+
+        after_relationship:        $result['relationship'] = $relationship;
 
         return $result;
     }

--- a/clients/GitHubEnterpriseCloud/src/Schema/AliasAbstract/Tiet1DA73592/TietBB556EE9/Tiet519FED8E/TietFC41A28A.php
+++ b/clients/GitHubEnterpriseCloud/src/Schema/AliasAbstract/Tiet1DA73592/TietBB556EE9/Tiet519FED8E/TietFC41A28A.php
@@ -2,12 +2,12 @@
 
 declare(strict_types=1);
 
-namespace ApiClients\Client\GitHubEnterpriseCloud\Schema\AliasAbstract\Tiet2BF61F22\TietD40E495C\TietD2DCD6B6;
+namespace ApiClients\Client\GitHubEnterpriseCloud\Schema\AliasAbstract\Tiet1DA73592\TietBB556EE9\Tiet519FED8E;
 
 use ApiClients\Client\GitHubEnterpriseCloud\Schema;
 use EventSauce\ObjectHydrator\MapFrom;
 
-abstract readonly class Tiet9D8D9B32
+abstract readonly class TietFC41A28A
 {
     public const SCHEMA_JSON         = '{
     "type": "object",
@@ -51,6 +51,20 @@ abstract readonly class Tiet9D8D9B32
             ],
             "description": "The execution scope of the vulnerable dependency.",
             "readOnly": true
+        },
+        "relationship": {
+            "enum": [
+                "unknown",
+                "direct",
+                "transitive",
+                null
+            ],
+            "type": [
+                "string",
+                "null"
+            ],
+            "description": "The vulnerable dependency\'s relationship to your project.\\n\\n> [!NOTE]\\n> We are rolling out support for dependency relationship across ecosystems. This value will be \\"unknown\\" for all dependencies in unsupported ecosystems.\\n",
+            "readOnly": true
         }
     },
     "description": "Details for the vulnerable dependency.",
@@ -64,16 +78,21 @@ abstract readonly class Tiet9D8D9B32
         "name": "generated"
     },
     "manifest_path": "generated",
-    "scope": "development"
+    "scope": "development",
+    "relationship": "transitive"
 }';
 
     /**
      * package: Details for the vulnerable package.
      * manifestPath: The full path to the dependency manifest file, relative to the root of the repository.
      * scope: The execution scope of the vulnerable dependency.
+     * relationship: The vulnerable dependency's relationship to your project.
+
+    > [!NOTE]
+    > We are rolling out support for dependency relationship across ecosystems. This value will be "unknown" for all dependencies in unsupported ecosystems.
      */
     public function __construct(public Schema\DependabotAlertPackage|null $package, #[MapFrom('manifest_path')]
-    public string|null $manifestPath, public string|null $scope,)
+    public string|null $manifestPath, public string|null $scope, public string|null $relationship,)
     {
     }
 }

--- a/clients/GitHubEnterpriseCloud/src/Schema/CodeSecurity/CreateConfigurationForEnterprise/Request/ApplicationJson.php
+++ b/clients/GitHubEnterpriseCloud/src/Schema/CodeSecurity/CreateConfigurationForEnterprise/Request/ApplicationJson.php
@@ -170,6 +170,16 @@ final readonly class ApplicationJson
             "description": "The enablement status of Copilot secret scanning",
             "default": "disabled"
         },
+        "secret_scanning_delegated_alert_dismissal": {
+            "enum": [
+                "enabled",
+                "disabled",
+                "not_set"
+            ],
+            "type": "string",
+            "description": "The enablement status of secret scanning delegated alert dismissal",
+            "default": "disabled"
+        },
         "private_vulnerability_reporting": {
             "enum": [
                 "enabled",
@@ -215,6 +225,7 @@ final readonly class ApplicationJson
     "secret_scanning_validity_checks": "enabled",
     "secret_scanning_non_provider_patterns": "enabled",
     "secret_scanning_generic_secrets": "enabled",
+    "secret_scanning_delegated_alert_dismissal": "enabled",
     "private_vulnerability_reporting": "enabled",
     "enforcement": "enforced"
 }';
@@ -235,6 +246,7 @@ final readonly class ApplicationJson
      * secretScanningValidityChecks: The enablement status of secret scanning validity checks
      * secretScanningNonProviderPatterns: The enablement status of secret scanning non provider patterns
      * secretScanningGenericSecrets: The enablement status of Copilot secret scanning
+     * secretScanningDelegatedAlertDismissal: The enablement status of secret scanning delegated alert dismissal
      * privateVulnerabilityReporting: The enablement status of private vulnerability reporting
      * enforcement: The enforcement status for a security configuration
      */
@@ -251,7 +263,8 @@ final readonly class ApplicationJson
     public string|null $secretScanningPushProtection, #[MapFrom('secret_scanning_validity_checks')]
     public string|null $secretScanningValidityChecks, #[MapFrom('secret_scanning_non_provider_patterns')]
     public string|null $secretScanningNonProviderPatterns, #[MapFrom('secret_scanning_generic_secrets')]
-    public string|null $secretScanningGenericSecrets, #[MapFrom('private_vulnerability_reporting')]
+    public string|null $secretScanningGenericSecrets, #[MapFrom('secret_scanning_delegated_alert_dismissal')]
+    public string|null $secretScanningDelegatedAlertDismissal, #[MapFrom('private_vulnerability_reporting')]
     public string|null $privateVulnerabilityReporting, public string|null $enforcement,)
     {
     }

--- a/clients/GitHubEnterpriseCloud/src/Schema/CodeSecurity/UpdateEnterpriseConfiguration/Request/ApplicationJson.php
+++ b/clients/GitHubEnterpriseCloud/src/Schema/CodeSecurity/UpdateEnterpriseConfiguration/Request/ApplicationJson.php
@@ -155,6 +155,16 @@ final readonly class ApplicationJson
             "description": "The enablement status of Copilot secret scanning",
             "default": "disabled"
         },
+        "secret_scanning_delegated_alert_dismissal": {
+            "enum": [
+                "enabled",
+                "disabled",
+                "not_set"
+            ],
+            "type": "string",
+            "description": "The enablement status of secret scanning delegated alert dismissal",
+            "default": "disabled"
+        },
         "private_vulnerability_reporting": {
             "enum": [
                 "enabled",
@@ -198,6 +208,7 @@ final readonly class ApplicationJson
     "secret_scanning_validity_checks": "enabled",
     "secret_scanning_non_provider_patterns": "enabled",
     "secret_scanning_generic_secrets": "enabled",
+    "secret_scanning_delegated_alert_dismissal": "enabled",
     "private_vulnerability_reporting": "enabled",
     "enforcement": "enforced"
 }';
@@ -218,6 +229,7 @@ final readonly class ApplicationJson
      * secretScanningValidityChecks: The enablement status of secret scanning validity checks
      * secretScanningNonProviderPatterns: The enablement status of secret scanning non-provider patterns
      * secretScanningGenericSecrets: The enablement status of Copilot secret scanning
+     * secretScanningDelegatedAlertDismissal: The enablement status of secret scanning delegated alert dismissal
      * privateVulnerabilityReporting: The enablement status of private vulnerability reporting
      * enforcement: The enforcement status for a security configuration
      */
@@ -234,7 +246,8 @@ final readonly class ApplicationJson
     public string|null $secretScanningPushProtection, #[MapFrom('secret_scanning_validity_checks')]
     public string|null $secretScanningValidityChecks, #[MapFrom('secret_scanning_non_provider_patterns')]
     public string|null $secretScanningNonProviderPatterns, #[MapFrom('secret_scanning_generic_secrets')]
-    public string|null $secretScanningGenericSecrets, #[MapFrom('private_vulnerability_reporting')]
+    public string|null $secretScanningGenericSecrets, #[MapFrom('secret_scanning_delegated_alert_dismissal')]
+    public string|null $secretScanningDelegatedAlertDismissal, #[MapFrom('private_vulnerability_reporting')]
     public string|null $privateVulnerabilityReporting, public string|null $enforcement,)
     {
     }

--- a/clients/GitHubEnterpriseCloud/src/Schema/DependabotAlert.php
+++ b/clients/GitHubEnterpriseCloud/src/Schema/DependabotAlert.php
@@ -86,6 +86,20 @@ final readonly class DependabotAlert
                     ],
                     "description": "The execution scope of the vulnerable dependency.",
                     "readOnly": true
+                },
+                "relationship": {
+                    "enum": [
+                        "unknown",
+                        "direct",
+                        "transitive",
+                        null
+                    ],
+                    "type": [
+                        "string",
+                        "null"
+                    ],
+                    "description": "The vulnerable dependency\'s relationship to your project.\\n\\n> [!NOTE]\\n> We are rolling out support for dependency relationship across ecosystems. This value will be \\"unknown\\" for all dependencies in unsupported ecosystems.\\n",
+                    "readOnly": true
                 }
             },
             "description": "Details for the vulnerable dependency.",
@@ -774,7 +788,8 @@ final readonly class DependabotAlert
             "name": "generated"
         },
         "manifest_path": "generated",
-        "scope": "development"
+        "scope": "development",
+        "relationship": "transitive"
     },
     "security_advisory": {
         "ghsa_id": "generated",

--- a/clients/GitHubEnterpriseCloud/src/Schema/DependabotAlert/Dependency.php
+++ b/clients/GitHubEnterpriseCloud/src/Schema/DependabotAlert/Dependency.php
@@ -6,6 +6,6 @@ namespace ApiClients\Client\GitHubEnterpriseCloud\Schema\DependabotAlert;
 
 use ApiClients\Client\GitHubEnterpriseCloud\Schema;
 
-final readonly class Dependency extends Schema\AliasAbstract\Tiet2BF61F22\TietD40E495C\TietD2DCD6B6\Tiet9D8D9B32
+final readonly class Dependency extends Schema\AliasAbstract\Tiet1DA73592\TietBB556EE9\Tiet519FED8E\TietFC41A28A
 {
 }

--- a/clients/GitHubEnterpriseCloud/src/Schema/DependabotAlertWithRepository.php
+++ b/clients/GitHubEnterpriseCloud/src/Schema/DependabotAlertWithRepository.php
@@ -87,6 +87,20 @@ final readonly class DependabotAlertWithRepository
                     ],
                     "description": "The execution scope of the vulnerable dependency.",
                     "readOnly": true
+                },
+                "relationship": {
+                    "enum": [
+                        "unknown",
+                        "direct",
+                        "transitive",
+                        null
+                    ],
+                    "type": [
+                        "string",
+                        "null"
+                    ],
+                    "description": "The vulnerable dependency\'s relationship to your project.\\n\\n> [!NOTE]\\n> We are rolling out support for dependency relationship across ecosystems. This value will be \\"unknown\\" for all dependencies in unsupported ecosystems.\\n",
+                    "readOnly": true
                 }
             },
             "description": "Details for the vulnerable dependency.",
@@ -1326,7 +1340,8 @@ final readonly class DependabotAlertWithRepository
             "name": "generated"
         },
         "manifest_path": "generated",
-        "scope": "development"
+        "scope": "development",
+        "relationship": "transitive"
     },
     "security_advisory": {
         "ghsa_id": "generated",

--- a/clients/GitHubEnterpriseCloud/src/Schema/DependabotAlertWithRepository/Dependency.php
+++ b/clients/GitHubEnterpriseCloud/src/Schema/DependabotAlertWithRepository/Dependency.php
@@ -6,6 +6,6 @@ namespace ApiClients\Client\GitHubEnterpriseCloud\Schema\DependabotAlertWithRepo
 
 use ApiClients\Client\GitHubEnterpriseCloud\Schema;
 
-final readonly class Dependency extends Schema\AliasAbstract\Tiet2BF61F22\TietD40E495C\TietD2DCD6B6\Tiet9D8D9B32
+final readonly class Dependency extends Schema\AliasAbstract\Tiet1DA73592\TietBB556EE9\Tiet519FED8E\TietFC41A28A
 {
 }

--- a/clients/GitHubEnterpriseCloud/src/Schema/WebhookDependabotAlertAutoDismissed.php
+++ b/clients/GitHubEnterpriseCloud/src/Schema/WebhookDependabotAlertAutoDismissed.php
@@ -101,6 +101,20 @@ final readonly class WebhookDependabotAlertAutoDismissed
                             ],
                             "description": "The execution scope of the vulnerable dependency.",
                             "readOnly": true
+                        },
+                        "relationship": {
+                            "enum": [
+                                "unknown",
+                                "direct",
+                                "transitive",
+                                null
+                            ],
+                            "type": [
+                                "string",
+                                "null"
+                            ],
+                            "description": "The vulnerable dependency\'s relationship to your project.\\n\\n> [!NOTE]\\n> We are rolling out support for dependency relationship across ecosystems. This value will be \\"unknown\\" for all dependencies in unsupported ecosystems.\\n",
+                            "readOnly": true
                         }
                     },
                     "description": "Details for the vulnerable dependency.",
@@ -2664,7 +2678,8 @@ final readonly class WebhookDependabotAlertAutoDismissed
                 "name": "generated"
             },
             "manifest_path": "generated",
-            "scope": "development"
+            "scope": "development",
+            "relationship": "transitive"
         },
         "security_advisory": {
             "ghsa_id": "generated",

--- a/clients/GitHubEnterpriseCloud/src/Schema/WebhookDependabotAlertAutoReopened.php
+++ b/clients/GitHubEnterpriseCloud/src/Schema/WebhookDependabotAlertAutoReopened.php
@@ -101,6 +101,20 @@ final readonly class WebhookDependabotAlertAutoReopened
                             ],
                             "description": "The execution scope of the vulnerable dependency.",
                             "readOnly": true
+                        },
+                        "relationship": {
+                            "enum": [
+                                "unknown",
+                                "direct",
+                                "transitive",
+                                null
+                            ],
+                            "type": [
+                                "string",
+                                "null"
+                            ],
+                            "description": "The vulnerable dependency\'s relationship to your project.\\n\\n> [!NOTE]\\n> We are rolling out support for dependency relationship across ecosystems. This value will be \\"unknown\\" for all dependencies in unsupported ecosystems.\\n",
+                            "readOnly": true
                         }
                     },
                     "description": "Details for the vulnerable dependency.",
@@ -2664,7 +2678,8 @@ final readonly class WebhookDependabotAlertAutoReopened
                 "name": "generated"
             },
             "manifest_path": "generated",
-            "scope": "development"
+            "scope": "development",
+            "relationship": "transitive"
         },
         "security_advisory": {
             "ghsa_id": "generated",

--- a/clients/GitHubEnterpriseCloud/src/Schema/WebhookDependabotAlertCreated.php
+++ b/clients/GitHubEnterpriseCloud/src/Schema/WebhookDependabotAlertCreated.php
@@ -101,6 +101,20 @@ final readonly class WebhookDependabotAlertCreated
                             ],
                             "description": "The execution scope of the vulnerable dependency.",
                             "readOnly": true
+                        },
+                        "relationship": {
+                            "enum": [
+                                "unknown",
+                                "direct",
+                                "transitive",
+                                null
+                            ],
+                            "type": [
+                                "string",
+                                "null"
+                            ],
+                            "description": "The vulnerable dependency\'s relationship to your project.\\n\\n> [!NOTE]\\n> We are rolling out support for dependency relationship across ecosystems. This value will be \\"unknown\\" for all dependencies in unsupported ecosystems.\\n",
+                            "readOnly": true
                         }
                     },
                     "description": "Details for the vulnerable dependency.",
@@ -2664,7 +2678,8 @@ final readonly class WebhookDependabotAlertCreated
                 "name": "generated"
             },
             "manifest_path": "generated",
-            "scope": "development"
+            "scope": "development",
+            "relationship": "transitive"
         },
         "security_advisory": {
             "ghsa_id": "generated",

--- a/clients/GitHubEnterpriseCloud/src/Schema/WebhookDependabotAlertDismissed.php
+++ b/clients/GitHubEnterpriseCloud/src/Schema/WebhookDependabotAlertDismissed.php
@@ -101,6 +101,20 @@ final readonly class WebhookDependabotAlertDismissed
                             ],
                             "description": "The execution scope of the vulnerable dependency.",
                             "readOnly": true
+                        },
+                        "relationship": {
+                            "enum": [
+                                "unknown",
+                                "direct",
+                                "transitive",
+                                null
+                            ],
+                            "type": [
+                                "string",
+                                "null"
+                            ],
+                            "description": "The vulnerable dependency\'s relationship to your project.\\n\\n> [!NOTE]\\n> We are rolling out support for dependency relationship across ecosystems. This value will be \\"unknown\\" for all dependencies in unsupported ecosystems.\\n",
+                            "readOnly": true
                         }
                     },
                     "description": "Details for the vulnerable dependency.",
@@ -2664,7 +2678,8 @@ final readonly class WebhookDependabotAlertDismissed
                 "name": "generated"
             },
             "manifest_path": "generated",
-            "scope": "development"
+            "scope": "development",
+            "relationship": "transitive"
         },
         "security_advisory": {
             "ghsa_id": "generated",

--- a/clients/GitHubEnterpriseCloud/src/Schema/WebhookDependabotAlertFixed.php
+++ b/clients/GitHubEnterpriseCloud/src/Schema/WebhookDependabotAlertFixed.php
@@ -101,6 +101,20 @@ final readonly class WebhookDependabotAlertFixed
                             ],
                             "description": "The execution scope of the vulnerable dependency.",
                             "readOnly": true
+                        },
+                        "relationship": {
+                            "enum": [
+                                "unknown",
+                                "direct",
+                                "transitive",
+                                null
+                            ],
+                            "type": [
+                                "string",
+                                "null"
+                            ],
+                            "description": "The vulnerable dependency\'s relationship to your project.\\n\\n> [!NOTE]\\n> We are rolling out support for dependency relationship across ecosystems. This value will be \\"unknown\\" for all dependencies in unsupported ecosystems.\\n",
+                            "readOnly": true
                         }
                     },
                     "description": "Details for the vulnerable dependency.",
@@ -2664,7 +2678,8 @@ final readonly class WebhookDependabotAlertFixed
                 "name": "generated"
             },
             "manifest_path": "generated",
-            "scope": "development"
+            "scope": "development",
+            "relationship": "transitive"
         },
         "security_advisory": {
             "ghsa_id": "generated",

--- a/clients/GitHubEnterpriseCloud/src/Schema/WebhookDependabotAlertReintroduced.php
+++ b/clients/GitHubEnterpriseCloud/src/Schema/WebhookDependabotAlertReintroduced.php
@@ -101,6 +101,20 @@ final readonly class WebhookDependabotAlertReintroduced
                             ],
                             "description": "The execution scope of the vulnerable dependency.",
                             "readOnly": true
+                        },
+                        "relationship": {
+                            "enum": [
+                                "unknown",
+                                "direct",
+                                "transitive",
+                                null
+                            ],
+                            "type": [
+                                "string",
+                                "null"
+                            ],
+                            "description": "The vulnerable dependency\'s relationship to your project.\\n\\n> [!NOTE]\\n> We are rolling out support for dependency relationship across ecosystems. This value will be \\"unknown\\" for all dependencies in unsupported ecosystems.\\n",
+                            "readOnly": true
                         }
                     },
                     "description": "Details for the vulnerable dependency.",
@@ -2664,7 +2678,8 @@ final readonly class WebhookDependabotAlertReintroduced
                 "name": "generated"
             },
             "manifest_path": "generated",
-            "scope": "development"
+            "scope": "development",
+            "relationship": "transitive"
         },
         "security_advisory": {
             "ghsa_id": "generated",

--- a/clients/GitHubEnterpriseCloud/src/Schema/WebhookDependabotAlertReopened.php
+++ b/clients/GitHubEnterpriseCloud/src/Schema/WebhookDependabotAlertReopened.php
@@ -101,6 +101,20 @@ final readonly class WebhookDependabotAlertReopened
                             ],
                             "description": "The execution scope of the vulnerable dependency.",
                             "readOnly": true
+                        },
+                        "relationship": {
+                            "enum": [
+                                "unknown",
+                                "direct",
+                                "transitive",
+                                null
+                            ],
+                            "type": [
+                                "string",
+                                "null"
+                            ],
+                            "description": "The vulnerable dependency\'s relationship to your project.\\n\\n> [!NOTE]\\n> We are rolling out support for dependency relationship across ecosystems. This value will be \\"unknown\\" for all dependencies in unsupported ecosystems.\\n",
+                            "readOnly": true
                         }
                     },
                     "description": "Details for the vulnerable dependency.",
@@ -2664,7 +2678,8 @@ final readonly class WebhookDependabotAlertReopened
                 "name": "generated"
             },
             "manifest_path": "generated",
-            "scope": "development"
+            "scope": "development",
+            "relationship": "transitive"
         },
         "security_advisory": {
             "ghsa_id": "generated",


### PR DESCRIPTION
Detected Schema changes:
2025-03-05 20:30:08 ERROR unable to open the rolodex file, check specification references and base path
                      ├ file: /__w/github-root/github-root/server-statistics-actions.yaml
                      └ error: open /__w/github-root/github-root/server-statistics-actions.yaml: no such file or directory
2025-03-05 20:30:08 ERROR unable to open the rolodex file, check specification references and base path
                      ├ file: /__w/github-root/github-root/server-statistics-packages.yaml
                      └ error: open /__w/github-root/github-root/server-statistics-packages.yaml: no such file or directory
2025-03-05 20:30:08 ERROR unable to open the rolodex file, check specification references and base path
                      ├ file: /__w/github-root/github-root/server-statistics-advisory-db.yaml
                      └ error: open /__w/github-root/github-root/server-statistics-advisory-db.yaml: no such file or directory
2025-03-05 20:30:10 ERROR unable to open the rolodex file, check specification references and base path
                      ├ file: /__w/github-root/github-root/server-statistics-actions.yaml
                      └ error: open /__w/github-root/github-root/server-statistics-actions.yaml: no such file or directory
2025-03-05 20:30:10 ERROR unable to open the rolodex file, check specification references and base path
                      ├ file: /__w/github-root/github-root/server-statistics-advisory-db.yaml
                      └ error: open /__w/github-root/github-root/server-statistics-advisory-db.yaml: no such file or directory
2025-03-05 20:30:10 ERROR unable to open the rolodex file, check specification references and base path
                      ├ file: /__w/github-root/github-root/server-statistics-packages.yaml
                      └ error: open /__w/github-root/github-root/server-statistics-packages.yaml: no such file or directory
ERROR: component `server-statistics-actions.yaml` does not exist in the specification
ERROR: component `server-statistics-packages.yaml` does not exist in the specification
ERROR: component `server-statistics-advisory-db.yaml` does not exist in the specification
ERROR: cannot resolve reference `server-statistics-actions.yaml`, it's missing: $.['server-statistics-actions.yaml'] [216396:11]
ERROR: cannot resolve reference `server-statistics-packages.yaml`, it's missing: $.['server-statistics-packages.yaml'] [216398:11]
ERROR: cannot resolve reference `server-statistics-advisory-db.yaml`, it's missing: $.['server-statistics-advisory-db.yaml'] [216400:11]
ERROR: component `server-statistics-actions.yaml` does not exist in the specification
ERROR: component `server-statistics-advisory-db.yaml` does not exist in the specification
ERROR: component `server-statistics-packages.yaml` does not exist in the specification
ERROR: cannot resolve reference `server-statistics-actions.yaml`, it's missing: $.['server-statistics-actions.yaml'] [216348:11]
ERROR: cannot resolve reference `server-statistics-packages.yaml`, it's missing: $.['server-statistics-packages.yaml'] [216350:11]
ERROR: cannot resolve reference `server-statistics-advisory-db.yaml`, it's missing: $.['server-statistics-advisory-db.yaml'] [216352:11]
