### PR TITLE
[GitHubEnterprise-3.13] Update to 1.1.4-b39b954044a7394ab4e5fe3ce2b56edc from 1.1.4-068189c2ddb887d39c830e1d08c2e36b

### DIFF
--- a/clients/GitHubEnterprise-3.13/etc/openapi-client-generator.state
+++ b/clients/GitHubEnterprise-3.13/etc/openapi-client-generator.state
@@ -1,5 +1,5 @@
 {
-    "specHash": "068189c2ddb887d39c830e1d08c2e36b",
+    "specHash": "b39b954044a7394ab4e5fe3ce2b56edc",
     "generatedFiles": {
         "files": [
             {
@@ -14092,7 +14092,7 @@
             },
             {
                 "name": ".\/clients\/GitHubEnterprise-3.13\/etc\/..\/\/src\/\/Schema\/RepositoryRulePullRequest.php",
-                "hash": "15bb1a04bb357d871d17cfa300df82a1"
+                "hash": "573164228d694e7e75c3bca8d85f8920"
             },
             {
                 "name": ".\/clients\/GitHubEnterprise-3.13\/etc\/..\/\/src\/\/Schema\/RepositoryRuleParamsStatusCheckConfiguration.php",
@@ -14136,7 +14136,7 @@
             },
             {
                 "name": ".\/clients\/GitHubEnterprise-3.13\/etc\/..\/\/src\/\/Schema\/RepositoryRule.php",
-                "hash": "22054f7104aef2a680f7bb8a38d88622"
+                "hash": "2528dcb6d9fac9eb0f473cd2ef681e57"
             },
             {
                 "name": ".\/clients\/GitHubEnterprise-3.13\/etc\/..\/\/src\/\/Internal\/Attribute\/CastUnionToType\/Schema\/RepositoryRuleset\/Conditions.php",
@@ -14144,7 +14144,7 @@
             },
             {
                 "name": ".\/clients\/GitHubEnterprise-3.13\/etc\/..\/\/src\/\/Schema\/RepositoryRuleset.php",
-                "hash": "3ce6a2bcf027d371fe3e7e3e93826b2c"
+                "hash": "9e5c13342d70c0e3037cccfc2ea7398a"
             },
             {
                 "name": ".\/clients\/GitHubEnterprise-3.13\/etc\/..\/\/src\/\/Schema\/RuleSuites.php",
@@ -14888,7 +14888,7 @@
             },
             {
                 "name": ".\/clients\/GitHubEnterprise-3.13\/etc\/..\/\/src\/\/Schema\/RepositoryRuleDetailed.php",
-                "hash": "f3f7f72f11915ad93bd068994ca86be4"
+                "hash": "69cd617db2dc79a08878e5937955e088"
             },
             {
                 "name": ".\/clients\/GitHubEnterprise-3.13\/etc\/..\/\/src\/\/Schema\/SecretScanningAlert.php",
@@ -16828,15 +16828,15 @@
             },
             {
                 "name": ".\/clients\/GitHubEnterprise-3.13\/etc\/..\/\/src\/\/Schema\/WebhookRepositoryRulesetCreated.php",
-                "hash": "0195cf695bbc4161dc3e1a988dc5418f"
+                "hash": "bf38af510fd326102d549c110f96e908"
             },
             {
                 "name": ".\/clients\/GitHubEnterprise-3.13\/etc\/..\/\/src\/\/Schema\/WebhookRepositoryRulesetDeleted.php",
-                "hash": "5ff4576c8e7187c986ce592bd14bba95"
+                "hash": "e8168d364dcc88771e9cafb617d5fdfa"
             },
             {
                 "name": ".\/clients\/GitHubEnterprise-3.13\/etc\/..\/\/src\/\/Schema\/WebhookRepositoryRulesetEdited.php",
-                "hash": "535ac0a4b731d389678244cd931a669e"
+                "hash": "2e9cf26c83833ebcbaa957e8bc2b86c6"
             },
             {
                 "name": ".\/clients\/GitHubEnterprise-3.13\/etc\/..\/\/src\/\/Schema\/WebhookRepositoryTransferred.php",
@@ -18036,7 +18036,7 @@
             },
             {
                 "name": ".\/clients\/GitHubEnterprise-3.13\/etc\/..\/\/src\/\/Schema\/RepositoryRulePullRequest\/Parameters.php",
-                "hash": "7447d661647fc5f5025273387f92be1a"
+                "hash": "f70745bb79bac14967633fd7512eab9c"
             },
             {
                 "name": ".\/clients\/GitHubEnterprise-3.13\/etc\/..\/\/src\/\/Schema\/RepositoryRuleRequiredStatusChecks\/Parameters.php",
@@ -23948,7 +23948,7 @@
             },
             {
                 "name": ".\/clients\/GitHubEnterprise-3.13\/etc\/..\/\/src\/\/Schema\/WebhookRepositoryRulesetEdited\/Changes.php",
-                "hash": "c4f1499fa21d77d2cdc113a73e192553"
+                "hash": "5eeea09363f7cf68d7c733f0f22283f2"
             },
             {
                 "name": ".\/clients\/GitHubEnterprise-3.13\/etc\/..\/\/src\/\/Schema\/WebhookRepositoryRulesetEdited\/Changes\/Conditions.php",
@@ -23976,7 +23976,7 @@
             },
             {
                 "name": ".\/clients\/GitHubEnterprise-3.13\/etc\/..\/\/src\/\/Schema\/WebhookRepositoryRulesetEdited\/Changes\/Rules.php",
-                "hash": "b694b6fdc6ccaec44cc66425710e27d0"
+                "hash": "8a169725b41beee3f092f92eae5eb606"
             },
             {
                 "name": ".\/clients\/GitHubEnterprise-3.13\/etc\/..\/\/src\/\/Internal\/Attribute\/CastUnionToType\/Schema\/WebhookRepositoryRulesetEdited\/Changes\/Rules\/Updated\/Rule.php",
@@ -23984,7 +23984,7 @@
             },
             {
                 "name": ".\/clients\/GitHubEnterprise-3.13\/etc\/..\/\/src\/\/Schema\/WebhookRepositoryRulesetEdited\/Changes\/Rules\/Updated.php",
-                "hash": "0f1717cf06b884b2bc0023ca3bdc39cf"
+                "hash": "a6a00ef391d3022b6c074653901cd1bf"
             },
             {
                 "name": ".\/clients\/GitHubEnterprise-3.13\/etc\/..\/\/src\/\/Schema\/WebhookRepositoryRulesetEdited\/Changes\/Rules\/Updated\/Changes.php",
@@ -25148,7 +25148,7 @@
             },
             {
                 "name": ".\/clients\/GitHubEnterprise-3.13\/etc\/..\/\/src\/\/Schema\/Repos\/CreateOrgRuleset\/Request\/ApplicationJson.php",
-                "hash": "501b32ebbc5d1cde52290bb5093856df"
+                "hash": "257c41e6b58db55494aa5c98fd8e665a"
             },
             {
                 "name": ".\/clients\/GitHubEnterprise-3.13\/etc\/..\/\/src\/\/Internal\/Attribute\/CastUnionToType\/Schema\/Repos\/UpdateOrgRuleset\/Request\/ApplicationJson\/Conditions.php",
@@ -25156,7 +25156,7 @@
             },
             {
                 "name": ".\/clients\/GitHubEnterprise-3.13\/etc\/..\/\/src\/\/Schema\/Repos\/UpdateOrgRuleset\/Request\/ApplicationJson.php",
-                "hash": "9479fd011dbec45b021a16e5b86d6328"
+                "hash": "c85c4b23bde720671cb8a8cdaf2286c9"
             },
             {
                 "name": ".\/clients\/GitHubEnterprise-3.13\/etc\/..\/\/src\/\/Schema\/Teams\/Create\/Request\/ApplicationJson.php",
@@ -26184,11 +26184,11 @@
             },
             {
                 "name": ".\/clients\/GitHubEnterprise-3.13\/etc\/..\/\/src\/\/Schema\/Repos\/CreateRepoRuleset\/Request\/ApplicationJson.php",
-                "hash": "9ae48be2467e7cc3a0d07410464d6a75"
+                "hash": "e2013dd0e8de28e7ef71c0d3f7ef98ed"
             },
             {
                 "name": ".\/clients\/GitHubEnterprise-3.13\/etc\/..\/\/src\/\/Schema\/Repos\/UpdateRepoRuleset\/Request\/ApplicationJson.php",
-                "hash": "aa64ba20d92249c90d949c4d3967cf7d"
+                "hash": "7a27ec1889fba24e3542cc853c847bfb"
             },
             {
                 "name": ".\/clients\/GitHubEnterprise-3.13\/etc\/..\/\/src\/\/Schema\/SecretScanning\/UpdateAlert\/Request\/ApplicationJson.php",

--- a/clients/GitHubEnterprise-3.13/src/Schema/Repos/CreateOrgRuleset/Request/ApplicationJson.php
+++ b/clients/GitHubEnterprise-3.13/src/Schema/Repos/CreateOrgRuleset/Request/ApplicationJson.php
@@ -487,6 +487,10 @@ final readonly class ApplicationJson
                                         },
                                         "description": "Array of allowed merge methods. Allowed values include `merge`, `squash`, and `rebase`. At least one option must be enabled."
                                     },
+                                    "automatic_copilot_code_review_enabled": {
+                                        "type": "boolean",
+                                        "description": "> [!NOTE]\\n> `automatic_copilot_code_review_enabled` is in beta and subject to change.\\n\\nAutomatically request review from Copilot for new pull requests, if the author has access to Copilot code review."
+                                    },
                                     "dismiss_stale_reviews_on_push": {
                                         "type": "boolean",
                                         "description": "New, reviewable commits pushed will dismiss previous pull request review approvals."

--- a/clients/GitHubEnterprise-3.13/src/Schema/Repos/CreateRepoRuleset/Request/ApplicationJson.php
+++ b/clients/GitHubEnterprise-3.13/src/Schema/Repos/CreateRepoRuleset/Request/ApplicationJson.php
@@ -268,6 +268,10 @@ final readonly class ApplicationJson
                                         },
                                         "description": "Array of allowed merge methods. Allowed values include `merge`, `squash`, and `rebase`. At least one option must be enabled."
                                     },
+                                    "automatic_copilot_code_review_enabled": {
+                                        "type": "boolean",
+                                        "description": "> [!NOTE]\\n> `automatic_copilot_code_review_enabled` is in beta and subject to change.\\n\\nAutomatically request review from Copilot for new pull requests, if the author has access to Copilot code review."
+                                    },
                                     "dismiss_stale_reviews_on_push": {
                                         "type": "boolean",
                                         "description": "New, reviewable commits pushed will dismiss previous pull request review approvals."

--- a/clients/GitHubEnterprise-3.13/src/Schema/Repos/UpdateOrgRuleset/Request/ApplicationJson.php
+++ b/clients/GitHubEnterprise-3.13/src/Schema/Repos/UpdateOrgRuleset/Request/ApplicationJson.php
@@ -482,6 +482,10 @@ final readonly class ApplicationJson
                                         },
                                         "description": "Array of allowed merge methods. Allowed values include `merge`, `squash`, and `rebase`. At least one option must be enabled."
                                     },
+                                    "automatic_copilot_code_review_enabled": {
+                                        "type": "boolean",
+                                        "description": "> [!NOTE]\\n> `automatic_copilot_code_review_enabled` is in beta and subject to change.\\n\\nAutomatically request review from Copilot for new pull requests, if the author has access to Copilot code review."
+                                    },
                                     "dismiss_stale_reviews_on_push": {
                                         "type": "boolean",
                                         "description": "New, reviewable commits pushed will dismiss previous pull request review approvals."

--- a/clients/GitHubEnterprise-3.13/src/Schema/Repos/UpdateRepoRuleset/Request/ApplicationJson.php
+++ b/clients/GitHubEnterprise-3.13/src/Schema/Repos/UpdateRepoRuleset/Request/ApplicationJson.php
@@ -263,6 +263,10 @@ final readonly class ApplicationJson
                                         },
                                         "description": "Array of allowed merge methods. Allowed values include `merge`, `squash`, and `rebase`. At least one option must be enabled."
                                     },
+                                    "automatic_copilot_code_review_enabled": {
+                                        "type": "boolean",
+                                        "description": "> [!NOTE]\\n> `automatic_copilot_code_review_enabled` is in beta and subject to change.\\n\\nAutomatically request review from Copilot for new pull requests, if the author has access to Copilot code review."
+                                    },
                                     "dismiss_stale_reviews_on_push": {
                                         "type": "boolean",
                                         "description": "New, reviewable commits pushed will dismiss previous pull request review approvals."

--- a/clients/GitHubEnterprise-3.13/src/Schema/RepositoryRule.php
+++ b/clients/GitHubEnterprise-3.13/src/Schema/RepositoryRule.php
@@ -168,6 +168,10 @@ final readonly class RepositoryRule
                             },
                             "description": "Array of allowed merge methods. Allowed values include `merge`, `squash`, and `rebase`. At least one option must be enabled."
                         },
+                        "automatic_copilot_code_review_enabled": {
+                            "type": "boolean",
+                            "description": "> [!NOTE]\\n> `automatic_copilot_code_review_enabled` is in beta and subject to change.\\n\\nAutomatically request review from Copilot for new pull requests, if the author has access to Copilot code review."
+                        },
                         "dismiss_stale_reviews_on_push": {
                             "type": "boolean",
                             "description": "New, reviewable commits pushed will dismiss previous pull request review approvals."

--- a/clients/GitHubEnterprise-3.13/src/Schema/RepositoryRuleDetailed.php
+++ b/clients/GitHubEnterprise-3.13/src/Schema/RepositoryRuleDetailed.php
@@ -326,6 +326,10 @@ final readonly class RepositoryRuleDetailed
                                     },
                                     "description": "Array of allowed merge methods. Allowed values include `merge`, `squash`, and `rebase`. At least one option must be enabled."
                                 },
+                                "automatic_copilot_code_review_enabled": {
+                                    "type": "boolean",
+                                    "description": "> [!NOTE]\\n> `automatic_copilot_code_review_enabled` is in beta and subject to change.\\n\\nAutomatically request review from Copilot for new pull requests, if the author has access to Copilot code review."
+                                },
                                 "dismiss_stale_reviews_on_push": {
                                     "type": "boolean",
                                     "description": "New, reviewable commits pushed will dismiss previous pull request review approvals."

--- a/clients/GitHubEnterprise-3.13/src/Schema/RepositoryRulePullRequest.php
+++ b/clients/GitHubEnterprise-3.13/src/Schema/RepositoryRulePullRequest.php
@@ -43,6 +43,10 @@ final readonly class RepositoryRulePullRequest
                     },
                     "description": "Array of allowed merge methods. Allowed values include `merge`, `squash`, and `rebase`. At least one option must be enabled."
                 },
+                "automatic_copilot_code_review_enabled": {
+                    "type": "boolean",
+                    "description": "> [!NOTE]\\n> `automatic_copilot_code_review_enabled` is in beta and subject to change.\\n\\nAutomatically request review from Copilot for new pull requests, if the author has access to Copilot code review."
+                },
                 "dismiss_stale_reviews_on_push": {
                     "type": "boolean",
                     "description": "New, reviewable commits pushed will dismiss previous pull request review approvals."
@@ -79,6 +83,7 @@ final readonly class RepositoryRulePullRequest
             "generated",
             "generated"
         ],
+        "automatic_copilot_code_review_enabled": false,
         "dismiss_stale_reviews_on_push": false,
         "require_code_owner_review": false,
         "require_last_push_approval": false,

--- a/clients/GitHubEnterprise-3.13/src/Schema/RepositoryRulePullRequest/Parameters.php
+++ b/clients/GitHubEnterprise-3.13/src/Schema/RepositoryRulePullRequest/Parameters.php
@@ -30,6 +30,10 @@ final readonly class Parameters
             },
             "description": "Array of allowed merge methods. Allowed values include `merge`, `squash`, and `rebase`. At least one option must be enabled."
         },
+        "automatic_copilot_code_review_enabled": {
+            "type": "boolean",
+            "description": "> [!NOTE]\\n> `automatic_copilot_code_review_enabled` is in beta and subject to change.\\n\\nAutomatically request review from Copilot for new pull requests, if the author has access to Copilot code review."
+        },
         "dismiss_stale_reviews_on_push": {
             "type": "boolean",
             "description": "New, reviewable commits pushed will dismiss previous pull request review approvals."
@@ -61,6 +65,7 @@ final readonly class Parameters
         "generated",
         "generated"
     ],
+    "automatic_copilot_code_review_enabled": false,
     "dismiss_stale_reviews_on_push": false,
     "require_code_owner_review": false,
     "require_last_push_approval": false,
@@ -70,6 +75,10 @@ final readonly class Parameters
 
     /**
      * allowedMergeMethods: Array of allowed merge methods. Allowed values include `merge`, `squash`, and `rebase`. At least one option must be enabled.
+     * automaticCopilotCodeReviewEnabled: > [!NOTE]
+    > `automatic_copilot_code_review_enabled` is in beta and subject to change.
+
+    Automatically request review from Copilot for new pull requests, if the author has access to Copilot code review.
      * dismissStaleReviewsOnPush: New, reviewable commits pushed will dismiss previous pull request review approvals.
      * requireCodeOwnerReview: Require an approving review in pull requests that modify files that have a designated code owner.
      * requireLastPushApproval: Whether the most recent reviewable push must be approved by someone other than the person who pushed it.
@@ -77,7 +86,8 @@ final readonly class Parameters
      * requiredReviewThreadResolution: All conversations on code must be resolved before a pull request can be merged.
      */
     public function __construct(#[MapFrom('allowed_merge_methods')]
-    public array|null $allowedMergeMethods, #[MapFrom('dismiss_stale_reviews_on_push')]
+    public array|null $allowedMergeMethods, #[MapFrom('automatic_copilot_code_review_enabled')]
+    public bool|null $automaticCopilotCodeReviewEnabled, #[MapFrom('dismiss_stale_reviews_on_push')]
     public bool $dismissStaleReviewsOnPush, #[MapFrom('require_code_owner_review')]
     public bool $requireCodeOwnerReview, #[MapFrom('require_last_push_approval')]
     public bool $requireLastPushApproval, #[MapFrom('required_approving_review_count')]

--- a/clients/GitHubEnterprise-3.13/src/Schema/RepositoryRuleset.php
+++ b/clients/GitHubEnterprise-3.13/src/Schema/RepositoryRuleset.php
@@ -577,6 +577,10 @@ final readonly class RepositoryRuleset
                                         },
                                         "description": "Array of allowed merge methods. Allowed values include `merge`, `squash`, and `rebase`. At least one option must be enabled."
                                     },
+                                    "automatic_copilot_code_review_enabled": {
+                                        "type": "boolean",
+                                        "description": "> [!NOTE]\\n> `automatic_copilot_code_review_enabled` is in beta and subject to change.\\n\\nAutomatically request review from Copilot for new pull requests, if the author has access to Copilot code review."
+                                    },
                                     "dismiss_stale_reviews_on_push": {
                                         "type": "boolean",
                                         "description": "New, reviewable commits pushed will dismiss previous pull request review approvals."

--- a/clients/GitHubEnterprise-3.13/src/Schema/WebhookRepositoryRulesetCreated.php
+++ b/clients/GitHubEnterprise-3.13/src/Schema/WebhookRepositoryRulesetCreated.php
@@ -2294,6 +2294,10 @@ final readonly class WebhookRepositoryRulesetCreated
                                                 },
                                                 "description": "Array of allowed merge methods. Allowed values include `merge`, `squash`, and `rebase`. At least one option must be enabled."
                                             },
+                                            "automatic_copilot_code_review_enabled": {
+                                                "type": "boolean",
+                                                "description": "> [!NOTE]\\n> `automatic_copilot_code_review_enabled` is in beta and subject to change.\\n\\nAutomatically request review from Copilot for new pull requests, if the author has access to Copilot code review."
+                                            },
                                             "dismiss_stale_reviews_on_push": {
                                                 "type": "boolean",
                                                 "description": "New, reviewable commits pushed will dismiss previous pull request review approvals."

--- a/clients/GitHubEnterprise-3.13/src/Schema/WebhookRepositoryRulesetDeleted.php
+++ b/clients/GitHubEnterprise-3.13/src/Schema/WebhookRepositoryRulesetDeleted.php
@@ -2294,6 +2294,10 @@ final readonly class WebhookRepositoryRulesetDeleted
                                                 },
                                                 "description": "Array of allowed merge methods. Allowed values include `merge`, `squash`, and `rebase`. At least one option must be enabled."
                                             },
+                                            "automatic_copilot_code_review_enabled": {
+                                                "type": "boolean",
+                                                "description": "> [!NOTE]\\n> `automatic_copilot_code_review_enabled` is in beta and subject to change.\\n\\nAutomatically request review from Copilot for new pull requests, if the author has access to Copilot code review."
+                                            },
                                             "dismiss_stale_reviews_on_push": {
                                                 "type": "boolean",
                                                 "description": "New, reviewable commits pushed will dismiss previous pull request review approvals."

--- a/clients/GitHubEnterprise-3.13/src/Schema/WebhookRepositoryRulesetEdited.php
+++ b/clients/GitHubEnterprise-3.13/src/Schema/WebhookRepositoryRulesetEdited.php
@@ -2294,6 +2294,10 @@ final readonly class WebhookRepositoryRulesetEdited
                                                 },
                                                 "description": "Array of allowed merge methods. Allowed values include `merge`, `squash`, and `rebase`. At least one option must be enabled."
                                             },
+                                            "automatic_copilot_code_review_enabled": {
+                                                "type": "boolean",
+                                                "description": "> [!NOTE]\\n> `automatic_copilot_code_review_enabled` is in beta and subject to change.\\n\\nAutomatically request review from Copilot for new pull requests, if the author has access to Copilot code review."
+                                            },
                                             "dismiss_stale_reviews_on_push": {
                                                 "type": "boolean",
                                                 "description": "New, reviewable commits pushed will dismiss previous pull request review approvals."
@@ -3027,6 +3031,10 @@ final readonly class WebhookRepositoryRulesetEdited
                                                         },
                                                         "description": "Array of allowed merge methods. Allowed values include `merge`, `squash`, and `rebase`. At least one option must be enabled."
                                                     },
+                                                    "automatic_copilot_code_review_enabled": {
+                                                        "type": "boolean",
+                                                        "description": "> [!NOTE]\\n> `automatic_copilot_code_review_enabled` is in beta and subject to change.\\n\\nAutomatically request review from Copilot for new pull requests, if the author has access to Copilot code review."
+                                                    },
                                                     "dismiss_stale_reviews_on_push": {
                                                         "type": "boolean",
                                                         "description": "New, reviewable commits pushed will dismiss previous pull request review approvals."
@@ -3586,6 +3594,10 @@ final readonly class WebhookRepositoryRulesetEdited
                                                             "type": "string"
                                                         },
                                                         "description": "Array of allowed merge methods. Allowed values include `merge`, `squash`, and `rebase`. At least one option must be enabled."
+                                                    },
+                                                    "automatic_copilot_code_review_enabled": {
+                                                        "type": "boolean",
+                                                        "description": "> [!NOTE]\\n> `automatic_copilot_code_review_enabled` is in beta and subject to change.\\n\\nAutomatically request review from Copilot for new pull requests, if the author has access to Copilot code review."
                                                     },
                                                     "dismiss_stale_reviews_on_push": {
                                                         "type": "boolean",
@@ -4149,6 +4161,10 @@ final readonly class WebhookRepositoryRulesetEdited
                                                                     "type": "string"
                                                                 },
                                                                 "description": "Array of allowed merge methods. Allowed values include `merge`, `squash`, and `rebase`. At least one option must be enabled."
+                                                            },
+                                                            "automatic_copilot_code_review_enabled": {
+                                                                "type": "boolean",
+                                                                "description": "> [!NOTE]\\n> `automatic_copilot_code_review_enabled` is in beta and subject to change.\\n\\nAutomatically request review from Copilot for new pull requests, if the author has access to Copilot code review."
                                                             },
                                                             "dismiss_stale_reviews_on_push": {
                                                                 "type": "boolean",

--- a/clients/GitHubEnterprise-3.13/src/Schema/WebhookRepositoryRulesetEdited/Changes.php
+++ b/clients/GitHubEnterprise-3.13/src/Schema/WebhookRepositoryRulesetEdited/Changes.php
@@ -334,6 +334,10 @@ final readonly class Changes
                                                 },
                                                 "description": "Array of allowed merge methods. Allowed values include `merge`, `squash`, and `rebase`. At least one option must be enabled."
                                             },
+                                            "automatic_copilot_code_review_enabled": {
+                                                "type": "boolean",
+                                                "description": "> [!NOTE]\\n> `automatic_copilot_code_review_enabled` is in beta and subject to change.\\n\\nAutomatically request review from Copilot for new pull requests, if the author has access to Copilot code review."
+                                            },
                                             "dismiss_stale_reviews_on_push": {
                                                 "type": "boolean",
                                                 "description": "New, reviewable commits pushed will dismiss previous pull request review approvals."
@@ -893,6 +897,10 @@ final readonly class Changes
                                                     "type": "string"
                                                 },
                                                 "description": "Array of allowed merge methods. Allowed values include `merge`, `squash`, and `rebase`. At least one option must be enabled."
+                                            },
+                                            "automatic_copilot_code_review_enabled": {
+                                                "type": "boolean",
+                                                "description": "> [!NOTE]\\n> `automatic_copilot_code_review_enabled` is in beta and subject to change.\\n\\nAutomatically request review from Copilot for new pull requests, if the author has access to Copilot code review."
                                             },
                                             "dismiss_stale_reviews_on_push": {
                                                 "type": "boolean",
@@ -1456,6 +1464,10 @@ final readonly class Changes
                                                             "type": "string"
                                                         },
                                                         "description": "Array of allowed merge methods. Allowed values include `merge`, `squash`, and `rebase`. At least one option must be enabled."
+                                                    },
+                                                    "automatic_copilot_code_review_enabled": {
+                                                        "type": "boolean",
+                                                        "description": "> [!NOTE]\\n> `automatic_copilot_code_review_enabled` is in beta and subject to change.\\n\\nAutomatically request review from Copilot for new pull requests, if the author has access to Copilot code review."
                                                     },
                                                     "dismiss_stale_reviews_on_push": {
                                                         "type": "boolean",

--- a/clients/GitHubEnterprise-3.13/src/Schema/WebhookRepositoryRulesetEdited/Changes/Rules.php
+++ b/clients/GitHubEnterprise-3.13/src/Schema/WebhookRepositoryRulesetEdited/Changes/Rules.php
@@ -173,6 +173,10 @@ final readonly class Rules
                                         },
                                         "description": "Array of allowed merge methods. Allowed values include `merge`, `squash`, and `rebase`. At least one option must be enabled."
                                     },
+                                    "automatic_copilot_code_review_enabled": {
+                                        "type": "boolean",
+                                        "description": "> [!NOTE]\\n> `automatic_copilot_code_review_enabled` is in beta and subject to change.\\n\\nAutomatically request review from Copilot for new pull requests, if the author has access to Copilot code review."
+                                    },
                                     "dismiss_stale_reviews_on_push": {
                                         "type": "boolean",
                                         "description": "New, reviewable commits pushed will dismiss previous pull request review approvals."
@@ -732,6 +736,10 @@ final readonly class Rules
                                             "type": "string"
                                         },
                                         "description": "Array of allowed merge methods. Allowed values include `merge`, `squash`, and `rebase`. At least one option must be enabled."
+                                    },
+                                    "automatic_copilot_code_review_enabled": {
+                                        "type": "boolean",
+                                        "description": "> [!NOTE]\\n> `automatic_copilot_code_review_enabled` is in beta and subject to change.\\n\\nAutomatically request review from Copilot for new pull requests, if the author has access to Copilot code review."
                                     },
                                     "dismiss_stale_reviews_on_push": {
                                         "type": "boolean",
@@ -1295,6 +1303,10 @@ final readonly class Rules
                                                     "type": "string"
                                                 },
                                                 "description": "Array of allowed merge methods. Allowed values include `merge`, `squash`, and `rebase`. At least one option must be enabled."
+                                            },
+                                            "automatic_copilot_code_review_enabled": {
+                                                "type": "boolean",
+                                                "description": "> [!NOTE]\\n> `automatic_copilot_code_review_enabled` is in beta and subject to change.\\n\\nAutomatically request review from Copilot for new pull requests, if the author has access to Copilot code review."
                                             },
                                             "dismiss_stale_reviews_on_push": {
                                                 "type": "boolean",

--- a/clients/GitHubEnterprise-3.13/src/Schema/WebhookRepositoryRulesetEdited/Changes/Rules/Updated.php
+++ b/clients/GitHubEnterprise-3.13/src/Schema/WebhookRepositoryRulesetEdited/Changes/Rules/Updated.php
@@ -174,6 +174,10 @@ final readonly class Updated
                                     },
                                     "description": "Array of allowed merge methods. Allowed values include `merge`, `squash`, and `rebase`. At least one option must be enabled."
                                 },
+                                "automatic_copilot_code_review_enabled": {
+                                    "type": "boolean",
+                                    "description": "> [!NOTE]\\n> `automatic_copilot_code_review_enabled` is in beta and subject to change.\\n\\nAutomatically request review from Copilot for new pull requests, if the author has access to Copilot code review."
+                                },
                                 "dismiss_stale_reviews_on_push": {
                                     "type": "boolean",
                                     "description": "New, reviewable commits pushed will dismiss previous pull request review approvals."


### PR DESCRIPTION
Detected Schema changes:



```
└─┬Components
  └─┬repository-rule-pull-request
    └─┬parameters
      └──[➖] properties (75392:13)❌ 

```

| Document Element | Total Changes | Breaking Changes |
|------------------|---------------|------------------|
| components       | 1             | 1                |

Date: 03/25/25 | Commit: Original: etc/specs/GitHubEnterprise-3.13/current.spec.yaml, Modified: etc/specs/GitHubEnterprise-3.13/previous.spec.yaml, 

- ❌ **BREAKING Changes**: _1_ out of _1_
- **Removals**: _1_
- **Breaking Removals**: _1_

ERROR: breaking changes discovered
