### PR TITLE
[GitHubEnterprise-3.14] Update to 1.1.4-fd3452e633ca20f3b19f783b723e8aae from 1.1.4-17c2c7428f307a53f2d8a29fc0b52750

### DIFF
--- a/clients/GitHubEnterprise-3.14/etc/openapi-client-generator.state
+++ b/clients/GitHubEnterprise-3.14/etc/openapi-client-generator.state
@@ -1,5 +1,5 @@
 {
-    "specHash": "17c2c7428f307a53f2d8a29fc0b52750",
+    "specHash": "fd3452e633ca20f3b19f783b723e8aae",
     "generatedFiles": {
         "files": [
             {
@@ -14284,7 +14284,7 @@
             },
             {
                 "name": ".\/clients\/GitHubEnterprise-3.14\/etc\/..\/\/src\/\/Schema\/RepositoryRulePullRequest.php",
-                "hash": "15bb1a04bb357d871d17cfa300df82a1"
+                "hash": "573164228d694e7e75c3bca8d85f8920"
             },
             {
                 "name": ".\/clients\/GitHubEnterprise-3.14\/etc\/..\/\/src\/\/Schema\/RepositoryRuleParamsStatusCheckConfiguration.php",
@@ -14336,7 +14336,7 @@
             },
             {
                 "name": ".\/clients\/GitHubEnterprise-3.14\/etc\/..\/\/src\/\/Schema\/RepositoryRule.php",
-                "hash": "9f0a0fa7d83fa33cafb05980add9e991"
+                "hash": "9a7a3a950a22d517ac3e4a910ed33898"
             },
             {
                 "name": ".\/clients\/GitHubEnterprise-3.14\/etc\/..\/\/src\/\/Internal\/Attribute\/CastUnionToType\/Schema\/RepositoryRuleset\/Conditions.php",
@@ -14344,7 +14344,7 @@
             },
             {
                 "name": ".\/clients\/GitHubEnterprise-3.14\/etc\/..\/\/src\/\/Schema\/RepositoryRuleset.php",
-                "hash": "2cbb915e89598340adf7f6d92664e6d5"
+                "hash": "d0d5d63bd42bee8e73f041d59efbe165"
             },
             {
                 "name": ".\/clients\/GitHubEnterprise-3.14\/etc\/..\/\/src\/\/Schema\/RuleSuites.php",
@@ -15084,7 +15084,7 @@
             },
             {
                 "name": ".\/clients\/GitHubEnterprise-3.14\/etc\/..\/\/src\/\/Schema\/RepositoryRuleDetailed.php",
-                "hash": "d3daf7bc723e92edb67043a2d08f9f31"
+                "hash": "22971e8b414e10ef9d6a266ef00054a5"
             },
             {
                 "name": ".\/clients\/GitHubEnterprise-3.14\/etc\/..\/\/src\/\/Schema\/SecretScanningAlert.php",
@@ -17084,15 +17084,15 @@
             },
             {
                 "name": ".\/clients\/GitHubEnterprise-3.14\/etc\/..\/\/src\/\/Schema\/WebhookRepositoryRulesetCreated.php",
-                "hash": "68568ff82a5ba2c8cdd1206bc10c0771"
+                "hash": "b1727ec38a9b1e219d0a2332f6ef3134"
             },
             {
                 "name": ".\/clients\/GitHubEnterprise-3.14\/etc\/..\/\/src\/\/Schema\/WebhookRepositoryRulesetDeleted.php",
-                "hash": "52d9a98a63a2c6c3dd7775220a90bd76"
+                "hash": "9233e197d04a50c85f3cb19229278ae4"
             },
             {
                 "name": ".\/clients\/GitHubEnterprise-3.14\/etc\/..\/\/src\/\/Schema\/WebhookRepositoryRulesetEdited.php",
-                "hash": "0481b20b57c52fd3be4623699cc39a9d"
+                "hash": "dc965941a5240d471bfa79fff6bc9cea"
             },
             {
                 "name": ".\/clients\/GitHubEnterprise-3.14\/etc\/..\/\/src\/\/Schema\/WebhookRepositoryTransferred.php",
@@ -18304,7 +18304,7 @@
             },
             {
                 "name": ".\/clients\/GitHubEnterprise-3.14\/etc\/..\/\/src\/\/Schema\/RepositoryRulePullRequest\/Parameters.php",
-                "hash": "7447d661647fc5f5025273387f92be1a"
+                "hash": "f70745bb79bac14967633fd7512eab9c"
             },
             {
                 "name": ".\/clients\/GitHubEnterprise-3.14\/etc\/..\/\/src\/\/Schema\/RepositoryRuleRequiredStatusChecks\/Parameters.php",
@@ -24240,7 +24240,7 @@
             },
             {
                 "name": ".\/clients\/GitHubEnterprise-3.14\/etc\/..\/\/src\/\/Schema\/WebhookRepositoryRulesetEdited\/Changes.php",
-                "hash": "1fbcce95dfceaff2a73ef1e3366134e9"
+                "hash": "967c68a535d947a7bba92d095d7bfb41"
             },
             {
                 "name": ".\/clients\/GitHubEnterprise-3.14\/etc\/..\/\/src\/\/Schema\/WebhookRepositoryRulesetEdited\/Changes\/Conditions.php",
@@ -24268,7 +24268,7 @@
             },
             {
                 "name": ".\/clients\/GitHubEnterprise-3.14\/etc\/..\/\/src\/\/Schema\/WebhookRepositoryRulesetEdited\/Changes\/Rules.php",
-                "hash": "1581192400a67163b8f2eea5628f9ee9"
+                "hash": "5cfdffac948f5894cad380dd0f8429e7"
             },
             {
                 "name": ".\/clients\/GitHubEnterprise-3.14\/etc\/..\/\/src\/\/Internal\/Attribute\/CastUnionToType\/Schema\/WebhookRepositoryRulesetEdited\/Changes\/Rules\/Updated\/Rule.php",
@@ -24276,7 +24276,7 @@
             },
             {
                 "name": ".\/clients\/GitHubEnterprise-3.14\/etc\/..\/\/src\/\/Schema\/WebhookRepositoryRulesetEdited\/Changes\/Rules\/Updated.php",
-                "hash": "54be095f8d392b7b3da59da641b54ad9"
+                "hash": "d8d22ae0b20baa57e3d679835e009eac"
             },
             {
                 "name": ".\/clients\/GitHubEnterprise-3.14\/etc\/..\/\/src\/\/Schema\/WebhookRepositoryRulesetEdited\/Changes\/Rules\/Updated\/Changes.php",
@@ -25444,7 +25444,7 @@
             },
             {
                 "name": ".\/clients\/GitHubEnterprise-3.14\/etc\/..\/\/src\/\/Schema\/Repos\/CreateOrgRuleset\/Request\/ApplicationJson.php",
-                "hash": "86736cdc3d679a6e1bcd951ae061e9ed"
+                "hash": "3fc2d11dbbbf053681ee3fd74180c864"
             },
             {
                 "name": ".\/clients\/GitHubEnterprise-3.14\/etc\/..\/\/src\/\/Internal\/Attribute\/CastUnionToType\/Schema\/Repos\/UpdateOrgRuleset\/Request\/ApplicationJson\/Conditions.php",
@@ -25452,7 +25452,7 @@
             },
             {
                 "name": ".\/clients\/GitHubEnterprise-3.14\/etc\/..\/\/src\/\/Schema\/Repos\/UpdateOrgRuleset\/Request\/ApplicationJson.php",
-                "hash": "2f08c9792734d2f94852ae7cac3789ae"
+                "hash": "44a8d4a234d94f2eb775d06a9f898586"
             },
             {
                 "name": ".\/clients\/GitHubEnterprise-3.14\/etc\/..\/\/src\/\/Schema\/Teams\/Create\/Request\/ApplicationJson.php",
@@ -26480,11 +26480,11 @@
             },
             {
                 "name": ".\/clients\/GitHubEnterprise-3.14\/etc\/..\/\/src\/\/Schema\/Repos\/CreateRepoRuleset\/Request\/ApplicationJson.php",
-                "hash": "762d3e2879a240697f873acc7b50ceaf"
+                "hash": "ad6d06c1fc22da28d339ec104b5be60f"
             },
             {
                 "name": ".\/clients\/GitHubEnterprise-3.14\/etc\/..\/\/src\/\/Schema\/Repos\/UpdateRepoRuleset\/Request\/ApplicationJson.php",
-                "hash": "1f02a69475986e068b6c26f5c99578ea"
+                "hash": "5207218c7e57417c04c307162453faec"
             },
             {
                 "name": ".\/clients\/GitHubEnterprise-3.14\/etc\/..\/\/src\/\/Schema\/SecretScanning\/UpdateAlert\/Request\/ApplicationJson.php",

--- a/clients/GitHubEnterprise-3.14/src/Schema/Repos/CreateOrgRuleset/Request/ApplicationJson.php
+++ b/clients/GitHubEnterprise-3.14/src/Schema/Repos/CreateOrgRuleset/Request/ApplicationJson.php
@@ -489,6 +489,10 @@ final readonly class ApplicationJson
                                         },
                                         "description": "Array of allowed merge methods. Allowed values include `merge`, `squash`, and `rebase`. At least one option must be enabled."
                                     },
+                                    "automatic_copilot_code_review_enabled": {
+                                        "type": "boolean",
+                                        "description": "> [!NOTE]\\n> `automatic_copilot_code_review_enabled` is in beta and subject to change.\\n\\nAutomatically request review from Copilot for new pull requests, if the author has access to Copilot code review."
+                                    },
                                     "dismiss_stale_reviews_on_push": {
                                         "type": "boolean",
                                         "description": "New, reviewable commits pushed will dismiss previous pull request review approvals."

--- a/clients/GitHubEnterprise-3.14/src/Schema/Repos/CreateRepoRuleset/Request/ApplicationJson.php
+++ b/clients/GitHubEnterprise-3.14/src/Schema/Repos/CreateRepoRuleset/Request/ApplicationJson.php
@@ -270,6 +270,10 @@ final readonly class ApplicationJson
                                         },
                                         "description": "Array of allowed merge methods. Allowed values include `merge`, `squash`, and `rebase`. At least one option must be enabled."
                                     },
+                                    "automatic_copilot_code_review_enabled": {
+                                        "type": "boolean",
+                                        "description": "> [!NOTE]\\n> `automatic_copilot_code_review_enabled` is in beta and subject to change.\\n\\nAutomatically request review from Copilot for new pull requests, if the author has access to Copilot code review."
+                                    },
                                     "dismiss_stale_reviews_on_push": {
                                         "type": "boolean",
                                         "description": "New, reviewable commits pushed will dismiss previous pull request review approvals."

--- a/clients/GitHubEnterprise-3.14/src/Schema/Repos/UpdateOrgRuleset/Request/ApplicationJson.php
+++ b/clients/GitHubEnterprise-3.14/src/Schema/Repos/UpdateOrgRuleset/Request/ApplicationJson.php
@@ -484,6 +484,10 @@ final readonly class ApplicationJson
                                         },
                                         "description": "Array of allowed merge methods. Allowed values include `merge`, `squash`, and `rebase`. At least one option must be enabled."
                                     },
+                                    "automatic_copilot_code_review_enabled": {
+                                        "type": "boolean",
+                                        "description": "> [!NOTE]\\n> `automatic_copilot_code_review_enabled` is in beta and subject to change.\\n\\nAutomatically request review from Copilot for new pull requests, if the author has access to Copilot code review."
+                                    },
                                     "dismiss_stale_reviews_on_push": {
                                         "type": "boolean",
                                         "description": "New, reviewable commits pushed will dismiss previous pull request review approvals."

--- a/clients/GitHubEnterprise-3.14/src/Schema/Repos/UpdateRepoRuleset/Request/ApplicationJson.php
+++ b/clients/GitHubEnterprise-3.14/src/Schema/Repos/UpdateRepoRuleset/Request/ApplicationJson.php
@@ -265,6 +265,10 @@ final readonly class ApplicationJson
                                         },
                                         "description": "Array of allowed merge methods. Allowed values include `merge`, `squash`, and `rebase`. At least one option must be enabled."
                                     },
+                                    "automatic_copilot_code_review_enabled": {
+                                        "type": "boolean",
+                                        "description": "> [!NOTE]\\n> `automatic_copilot_code_review_enabled` is in beta and subject to change.\\n\\nAutomatically request review from Copilot for new pull requests, if the author has access to Copilot code review."
+                                    },
                                     "dismiss_stale_reviews_on_push": {
                                         "type": "boolean",
                                         "description": "New, reviewable commits pushed will dismiss previous pull request review approvals."

--- a/clients/GitHubEnterprise-3.14/src/Schema/RepositoryRule.php
+++ b/clients/GitHubEnterprise-3.14/src/Schema/RepositoryRule.php
@@ -168,6 +168,10 @@ final readonly class RepositoryRule
                             },
                             "description": "Array of allowed merge methods. Allowed values include `merge`, `squash`, and `rebase`. At least one option must be enabled."
                         },
+                        "automatic_copilot_code_review_enabled": {
+                            "type": "boolean",
+                            "description": "> [!NOTE]\\n> `automatic_copilot_code_review_enabled` is in beta and subject to change.\\n\\nAutomatically request review from Copilot for new pull requests, if the author has access to Copilot code review."
+                        },
                         "dismiss_stale_reviews_on_push": {
                             "type": "boolean",
                             "description": "New, reviewable commits pushed will dismiss previous pull request review approvals."

--- a/clients/GitHubEnterprise-3.14/src/Schema/RepositoryRuleDetailed.php
+++ b/clients/GitHubEnterprise-3.14/src/Schema/RepositoryRuleDetailed.php
@@ -326,6 +326,10 @@ final readonly class RepositoryRuleDetailed
                                     },
                                     "description": "Array of allowed merge methods. Allowed values include `merge`, `squash`, and `rebase`. At least one option must be enabled."
                                 },
+                                "automatic_copilot_code_review_enabled": {
+                                    "type": "boolean",
+                                    "description": "> [!NOTE]\\n> `automatic_copilot_code_review_enabled` is in beta and subject to change.\\n\\nAutomatically request review from Copilot for new pull requests, if the author has access to Copilot code review."
+                                },
                                 "dismiss_stale_reviews_on_push": {
                                     "type": "boolean",
                                     "description": "New, reviewable commits pushed will dismiss previous pull request review approvals."

--- a/clients/GitHubEnterprise-3.14/src/Schema/RepositoryRulePullRequest.php
+++ b/clients/GitHubEnterprise-3.14/src/Schema/RepositoryRulePullRequest.php
@@ -43,6 +43,10 @@ final readonly class RepositoryRulePullRequest
                     },
                     "description": "Array of allowed merge methods. Allowed values include `merge`, `squash`, and `rebase`. At least one option must be enabled."
                 },
+                "automatic_copilot_code_review_enabled": {
+                    "type": "boolean",
+                    "description": "> [!NOTE]\\n> `automatic_copilot_code_review_enabled` is in beta and subject to change.\\n\\nAutomatically request review from Copilot for new pull requests, if the author has access to Copilot code review."
+                },
                 "dismiss_stale_reviews_on_push": {
                     "type": "boolean",
                     "description": "New, reviewable commits pushed will dismiss previous pull request review approvals."
@@ -79,6 +83,7 @@ final readonly class RepositoryRulePullRequest
             "generated",
             "generated"
         ],
+        "automatic_copilot_code_review_enabled": false,
         "dismiss_stale_reviews_on_push": false,
         "require_code_owner_review": false,
         "require_last_push_approval": false,

--- a/clients/GitHubEnterprise-3.14/src/Schema/RepositoryRulePullRequest/Parameters.php
+++ b/clients/GitHubEnterprise-3.14/src/Schema/RepositoryRulePullRequest/Parameters.php
@@ -30,6 +30,10 @@ final readonly class Parameters
             },
             "description": "Array of allowed merge methods. Allowed values include `merge`, `squash`, and `rebase`. At least one option must be enabled."
         },
+        "automatic_copilot_code_review_enabled": {
+            "type": "boolean",
+            "description": "> [!NOTE]\\n> `automatic_copilot_code_review_enabled` is in beta and subject to change.\\n\\nAutomatically request review from Copilot for new pull requests, if the author has access to Copilot code review."
+        },
         "dismiss_stale_reviews_on_push": {
             "type": "boolean",
             "description": "New, reviewable commits pushed will dismiss previous pull request review approvals."
@@ -61,6 +65,7 @@ final readonly class Parameters
         "generated",
         "generated"
     ],
+    "automatic_copilot_code_review_enabled": false,
     "dismiss_stale_reviews_on_push": false,
     "require_code_owner_review": false,
     "require_last_push_approval": false,
@@ -70,6 +75,10 @@ final readonly class Parameters
 
     /**
      * allowedMergeMethods: Array of allowed merge methods. Allowed values include `merge`, `squash`, and `rebase`. At least one option must be enabled.
+     * automaticCopilotCodeReviewEnabled: > [!NOTE]
+    > `automatic_copilot_code_review_enabled` is in beta and subject to change.
+
+    Automatically request review from Copilot for new pull requests, if the author has access to Copilot code review.
      * dismissStaleReviewsOnPush: New, reviewable commits pushed will dismiss previous pull request review approvals.
      * requireCodeOwnerReview: Require an approving review in pull requests that modify files that have a designated code owner.
      * requireLastPushApproval: Whether the most recent reviewable push must be approved by someone other than the person who pushed it.
@@ -77,7 +86,8 @@ final readonly class Parameters
      * requiredReviewThreadResolution: All conversations on code must be resolved before a pull request can be merged.
      */
     public function __construct(#[MapFrom('allowed_merge_methods')]
-    public array|null $allowedMergeMethods, #[MapFrom('dismiss_stale_reviews_on_push')]
+    public array|null $allowedMergeMethods, #[MapFrom('automatic_copilot_code_review_enabled')]
+    public bool|null $automaticCopilotCodeReviewEnabled, #[MapFrom('dismiss_stale_reviews_on_push')]
     public bool $dismissStaleReviewsOnPush, #[MapFrom('require_code_owner_review')]
     public bool $requireCodeOwnerReview, #[MapFrom('require_last_push_approval')]
     public bool $requireLastPushApproval, #[MapFrom('required_approving_review_count')]

--- a/clients/GitHubEnterprise-3.14/src/Schema/RepositoryRuleset.php
+++ b/clients/GitHubEnterprise-3.14/src/Schema/RepositoryRuleset.php
@@ -579,6 +579,10 @@ final readonly class RepositoryRuleset
                                         },
                                         "description": "Array of allowed merge methods. Allowed values include `merge`, `squash`, and `rebase`. At least one option must be enabled."
                                     },
+                                    "automatic_copilot_code_review_enabled": {
+                                        "type": "boolean",
+                                        "description": "> [!NOTE]\\n> `automatic_copilot_code_review_enabled` is in beta and subject to change.\\n\\nAutomatically request review from Copilot for new pull requests, if the author has access to Copilot code review."
+                                    },
                                     "dismiss_stale_reviews_on_push": {
                                         "type": "boolean",
                                         "description": "New, reviewable commits pushed will dismiss previous pull request review approvals."

--- a/clients/GitHubEnterprise-3.14/src/Schema/WebhookRepositoryRulesetCreated.php
+++ b/clients/GitHubEnterprise-3.14/src/Schema/WebhookRepositoryRulesetCreated.php
@@ -2296,6 +2296,10 @@ final readonly class WebhookRepositoryRulesetCreated
                                                 },
                                                 "description": "Array of allowed merge methods. Allowed values include `merge`, `squash`, and `rebase`. At least one option must be enabled."
                                             },
+                                            "automatic_copilot_code_review_enabled": {
+                                                "type": "boolean",
+                                                "description": "> [!NOTE]\\n> `automatic_copilot_code_review_enabled` is in beta and subject to change.\\n\\nAutomatically request review from Copilot for new pull requests, if the author has access to Copilot code review."
+                                            },
                                             "dismiss_stale_reviews_on_push": {
                                                 "type": "boolean",
                                                 "description": "New, reviewable commits pushed will dismiss previous pull request review approvals."

--- a/clients/GitHubEnterprise-3.14/src/Schema/WebhookRepositoryRulesetDeleted.php
+++ b/clients/GitHubEnterprise-3.14/src/Schema/WebhookRepositoryRulesetDeleted.php
@@ -2296,6 +2296,10 @@ final readonly class WebhookRepositoryRulesetDeleted
                                                 },
                                                 "description": "Array of allowed merge methods. Allowed values include `merge`, `squash`, and `rebase`. At least one option must be enabled."
                                             },
+                                            "automatic_copilot_code_review_enabled": {
+                                                "type": "boolean",
+                                                "description": "> [!NOTE]\\n> `automatic_copilot_code_review_enabled` is in beta and subject to change.\\n\\nAutomatically request review from Copilot for new pull requests, if the author has access to Copilot code review."
+                                            },
                                             "dismiss_stale_reviews_on_push": {
                                                 "type": "boolean",
                                                 "description": "New, reviewable commits pushed will dismiss previous pull request review approvals."

--- a/clients/GitHubEnterprise-3.14/src/Schema/WebhookRepositoryRulesetEdited.php
+++ b/clients/GitHubEnterprise-3.14/src/Schema/WebhookRepositoryRulesetEdited.php
@@ -2296,6 +2296,10 @@ final readonly class WebhookRepositoryRulesetEdited
                                                 },
                                                 "description": "Array of allowed merge methods. Allowed values include `merge`, `squash`, and `rebase`. At least one option must be enabled."
                                             },
+                                            "automatic_copilot_code_review_enabled": {
+                                                "type": "boolean",
+                                                "description": "> [!NOTE]\\n> `automatic_copilot_code_review_enabled` is in beta and subject to change.\\n\\nAutomatically request review from Copilot for new pull requests, if the author has access to Copilot code review."
+                                            },
                                             "dismiss_stale_reviews_on_push": {
                                                 "type": "boolean",
                                                 "description": "New, reviewable commits pushed will dismiss previous pull request review approvals."
@@ -3094,6 +3098,10 @@ final readonly class WebhookRepositoryRulesetEdited
                                                         },
                                                         "description": "Array of allowed merge methods. Allowed values include `merge`, `squash`, and `rebase`. At least one option must be enabled."
                                                     },
+                                                    "automatic_copilot_code_review_enabled": {
+                                                        "type": "boolean",
+                                                        "description": "> [!NOTE]\\n> `automatic_copilot_code_review_enabled` is in beta and subject to change.\\n\\nAutomatically request review from Copilot for new pull requests, if the author has access to Copilot code review."
+                                                    },
                                                     "dismiss_stale_reviews_on_push": {
                                                         "type": "boolean",
                                                         "description": "New, reviewable commits pushed will dismiss previous pull request review approvals."
@@ -3718,6 +3726,10 @@ final readonly class WebhookRepositoryRulesetEdited
                                                             "type": "string"
                                                         },
                                                         "description": "Array of allowed merge methods. Allowed values include `merge`, `squash`, and `rebase`. At least one option must be enabled."
+                                                    },
+                                                    "automatic_copilot_code_review_enabled": {
+                                                        "type": "boolean",
+                                                        "description": "> [!NOTE]\\n> `automatic_copilot_code_review_enabled` is in beta and subject to change.\\n\\nAutomatically request review from Copilot for new pull requests, if the author has access to Copilot code review."
                                                     },
                                                     "dismiss_stale_reviews_on_push": {
                                                         "type": "boolean",
@@ -4346,6 +4358,10 @@ final readonly class WebhookRepositoryRulesetEdited
                                                                     "type": "string"
                                                                 },
                                                                 "description": "Array of allowed merge methods. Allowed values include `merge`, `squash`, and `rebase`. At least one option must be enabled."
+                                                            },
+                                                            "automatic_copilot_code_review_enabled": {
+                                                                "type": "boolean",
+                                                                "description": "> [!NOTE]\\n> `automatic_copilot_code_review_enabled` is in beta and subject to change.\\n\\nAutomatically request review from Copilot for new pull requests, if the author has access to Copilot code review."
                                                             },
                                                             "dismiss_stale_reviews_on_push": {
                                                                 "type": "boolean",

--- a/clients/GitHubEnterprise-3.14/src/Schema/WebhookRepositoryRulesetEdited/Changes.php
+++ b/clients/GitHubEnterprise-3.14/src/Schema/WebhookRepositoryRulesetEdited/Changes.php
@@ -334,6 +334,10 @@ final readonly class Changes
                                                 },
                                                 "description": "Array of allowed merge methods. Allowed values include `merge`, `squash`, and `rebase`. At least one option must be enabled."
                                             },
+                                            "automatic_copilot_code_review_enabled": {
+                                                "type": "boolean",
+                                                "description": "> [!NOTE]\\n> `automatic_copilot_code_review_enabled` is in beta and subject to change.\\n\\nAutomatically request review from Copilot for new pull requests, if the author has access to Copilot code review."
+                                            },
                                             "dismiss_stale_reviews_on_push": {
                                                 "type": "boolean",
                                                 "description": "New, reviewable commits pushed will dismiss previous pull request review approvals."
@@ -958,6 +962,10 @@ final readonly class Changes
                                                     "type": "string"
                                                 },
                                                 "description": "Array of allowed merge methods. Allowed values include `merge`, `squash`, and `rebase`. At least one option must be enabled."
+                                            },
+                                            "automatic_copilot_code_review_enabled": {
+                                                "type": "boolean",
+                                                "description": "> [!NOTE]\\n> `automatic_copilot_code_review_enabled` is in beta and subject to change.\\n\\nAutomatically request review from Copilot for new pull requests, if the author has access to Copilot code review."
                                             },
                                             "dismiss_stale_reviews_on_push": {
                                                 "type": "boolean",
@@ -1586,6 +1594,10 @@ final readonly class Changes
                                                             "type": "string"
                                                         },
                                                         "description": "Array of allowed merge methods. Allowed values include `merge`, `squash`, and `rebase`. At least one option must be enabled."
+                                                    },
+                                                    "automatic_copilot_code_review_enabled": {
+                                                        "type": "boolean",
+                                                        "description": "> [!NOTE]\\n> `automatic_copilot_code_review_enabled` is in beta and subject to change.\\n\\nAutomatically request review from Copilot for new pull requests, if the author has access to Copilot code review."
                                                     },
                                                     "dismiss_stale_reviews_on_push": {
                                                         "type": "boolean",

--- a/clients/GitHubEnterprise-3.14/src/Schema/WebhookRepositoryRulesetEdited/Changes/Rules.php
+++ b/clients/GitHubEnterprise-3.14/src/Schema/WebhookRepositoryRulesetEdited/Changes/Rules.php
@@ -173,6 +173,10 @@ final readonly class Rules
                                         },
                                         "description": "Array of allowed merge methods. Allowed values include `merge`, `squash`, and `rebase`. At least one option must be enabled."
                                     },
+                                    "automatic_copilot_code_review_enabled": {
+                                        "type": "boolean",
+                                        "description": "> [!NOTE]\\n> `automatic_copilot_code_review_enabled` is in beta and subject to change.\\n\\nAutomatically request review from Copilot for new pull requests, if the author has access to Copilot code review."
+                                    },
                                     "dismiss_stale_reviews_on_push": {
                                         "type": "boolean",
                                         "description": "New, reviewable commits pushed will dismiss previous pull request review approvals."
@@ -797,6 +801,10 @@ final readonly class Rules
                                             "type": "string"
                                         },
                                         "description": "Array of allowed merge methods. Allowed values include `merge`, `squash`, and `rebase`. At least one option must be enabled."
+                                    },
+                                    "automatic_copilot_code_review_enabled": {
+                                        "type": "boolean",
+                                        "description": "> [!NOTE]\\n> `automatic_copilot_code_review_enabled` is in beta and subject to change.\\n\\nAutomatically request review from Copilot for new pull requests, if the author has access to Copilot code review."
                                     },
                                     "dismiss_stale_reviews_on_push": {
                                         "type": "boolean",
@@ -1425,6 +1433,10 @@ final readonly class Rules
                                                     "type": "string"
                                                 },
                                                 "description": "Array of allowed merge methods. Allowed values include `merge`, `squash`, and `rebase`. At least one option must be enabled."
+                                            },
+                                            "automatic_copilot_code_review_enabled": {
+                                                "type": "boolean",
+                                                "description": "> [!NOTE]\\n> `automatic_copilot_code_review_enabled` is in beta and subject to change.\\n\\nAutomatically request review from Copilot for new pull requests, if the author has access to Copilot code review."
                                             },
                                             "dismiss_stale_reviews_on_push": {
                                                 "type": "boolean",

--- a/clients/GitHubEnterprise-3.14/src/Schema/WebhookRepositoryRulesetEdited/Changes/Rules/Updated.php
+++ b/clients/GitHubEnterprise-3.14/src/Schema/WebhookRepositoryRulesetEdited/Changes/Rules/Updated.php
@@ -174,6 +174,10 @@ final readonly class Updated
                                     },
                                     "description": "Array of allowed merge methods. Allowed values include `merge`, `squash`, and `rebase`. At least one option must be enabled."
                                 },
+                                "automatic_copilot_code_review_enabled": {
+                                    "type": "boolean",
+                                    "description": "> [!NOTE]\\n> `automatic_copilot_code_review_enabled` is in beta and subject to change.\\n\\nAutomatically request review from Copilot for new pull requests, if the author has access to Copilot code review."
+                                },
                                 "dismiss_stale_reviews_on_push": {
                                     "type": "boolean",
                                     "description": "New, reviewable commits pushed will dismiss previous pull request review approvals."


### PR DESCRIPTION
Detected Schema changes:



```
└─┬Components
  └─┬repository-rule-pull-request
    └─┬parameters
      └──[➖] properties (76780:13)❌ 

```

| Document Element | Total Changes | Breaking Changes |
|------------------|---------------|------------------|
| components       | 1             | 1                |

Date: 03/25/25 | Commit: Original: etc/specs/GitHubEnterprise-3.14/current.spec.yaml, Modified: etc/specs/GitHubEnterprise-3.14/previous.spec.yaml, 

- ❌ **BREAKING Changes**: _1_ out of _1_
- **Removals**: _1_
- **Breaking Removals**: _1_

ERROR: breaking changes discovered
