### PR TITLE
[GitHubEnterprise-3.15] Update to 1.1.4-c839dc4b91fdd6e7b4bb4312c26a3e3d from 1.1.4-55f74f3e5247a80d845e796bbe3a0f26

### DIFF
--- a/clients/GitHubEnterprise-3.15/etc/openapi-client-generator.state
+++ b/clients/GitHubEnterprise-3.15/etc/openapi-client-generator.state
@@ -1,5 +1,5 @@
 {
-    "specHash": "55f74f3e5247a80d845e796bbe3a0f26",
+    "specHash": "c839dc4b91fdd6e7b4bb4312c26a3e3d",
     "generatedFiles": {
         "files": [
             {
@@ -14328,7 +14328,7 @@
             },
             {
                 "name": ".\/clients\/GitHubEnterprise-3.15\/etc\/..\/\/src\/\/Schema\/RepositoryRulePullRequest.php",
-                "hash": "15bb1a04bb357d871d17cfa300df82a1"
+                "hash": "573164228d694e7e75c3bca8d85f8920"
             },
             {
                 "name": ".\/clients\/GitHubEnterprise-3.15\/etc\/..\/\/src\/\/Schema\/RepositoryRuleParamsStatusCheckConfiguration.php",
@@ -14380,7 +14380,7 @@
             },
             {
                 "name": ".\/clients\/GitHubEnterprise-3.15\/etc\/..\/\/src\/\/Schema\/RepositoryRule.php",
-                "hash": "6c546d8162a1757ce9cc1f4f6b718456"
+                "hash": "966d8ccdc794dd25dddfae4ab8b3368e"
             },
             {
                 "name": ".\/clients\/GitHubEnterprise-3.15\/etc\/..\/\/src\/\/Internal\/Attribute\/CastUnionToType\/Schema\/RepositoryRuleset\/Conditions.php",
@@ -14388,7 +14388,7 @@
             },
             {
                 "name": ".\/clients\/GitHubEnterprise-3.15\/etc\/..\/\/src\/\/Schema\/RepositoryRuleset.php",
-                "hash": "21186b4aa09b675995e821775bf9fc18"
+                "hash": "3993f8688b6cfa0fbeea357328b158a6"
             },
             {
                 "name": ".\/clients\/GitHubEnterprise-3.15\/etc\/..\/\/src\/\/Schema\/RuleSuites.php",
@@ -15132,7 +15132,7 @@
             },
             {
                 "name": ".\/clients\/GitHubEnterprise-3.15\/etc\/..\/\/src\/\/Schema\/RepositoryRuleDetailed.php",
-                "hash": "649a5cbd79f4ae0e4b26ec6815206f35"
+                "hash": "f156fda303bcad6e9ad333993ca9e173"
             },
             {
                 "name": ".\/clients\/GitHubEnterprise-3.15\/etc\/..\/\/src\/\/Schema\/SecretScanningAlert.php",
@@ -17124,15 +17124,15 @@
             },
             {
                 "name": ".\/clients\/GitHubEnterprise-3.15\/etc\/..\/\/src\/\/Schema\/WebhookRepositoryRulesetCreated.php",
-                "hash": "0cfb5201265e57bd2d3467f2fd30ae87"
+                "hash": "5029294d7b82c272059a7b60e42515d6"
             },
             {
                 "name": ".\/clients\/GitHubEnterprise-3.15\/etc\/..\/\/src\/\/Schema\/WebhookRepositoryRulesetDeleted.php",
-                "hash": "b15199b01bb95a563104a9e1277ebe1f"
+                "hash": "356e7ff2b9b817dad5dc78ee42321255"
             },
             {
                 "name": ".\/clients\/GitHubEnterprise-3.15\/etc\/..\/\/src\/\/Schema\/WebhookRepositoryRulesetEdited.php",
-                "hash": "e44e0fb9224ec3e781014cc7b2e30616"
+                "hash": "9065be8ef953ddbe45901df46782b0f9"
             },
             {
                 "name": ".\/clients\/GitHubEnterprise-3.15\/etc\/..\/\/src\/\/Schema\/WebhookRepositoryTransferred.php",
@@ -18268,7 +18268,7 @@
             },
             {
                 "name": ".\/clients\/GitHubEnterprise-3.15\/etc\/..\/\/src\/\/Schema\/RepositoryRulePullRequest\/Parameters.php",
-                "hash": "7447d661647fc5f5025273387f92be1a"
+                "hash": "f70745bb79bac14967633fd7512eab9c"
             },
             {
                 "name": ".\/clients\/GitHubEnterprise-3.15\/etc\/..\/\/src\/\/Schema\/RepositoryRuleRequiredStatusChecks\/Parameters.php",
@@ -24196,7 +24196,7 @@
             },
             {
                 "name": ".\/clients\/GitHubEnterprise-3.15\/etc\/..\/\/src\/\/Schema\/WebhookRepositoryRulesetEdited\/Changes.php",
-                "hash": "53c1de2ea1d8aa69cee3f981186b7773"
+                "hash": "946552e684d3a91bd0440e839e7e8b84"
             },
             {
                 "name": ".\/clients\/GitHubEnterprise-3.15\/etc\/..\/\/src\/\/Schema\/WebhookRepositoryRulesetEdited\/Changes\/Conditions.php",
@@ -24224,7 +24224,7 @@
             },
             {
                 "name": ".\/clients\/GitHubEnterprise-3.15\/etc\/..\/\/src\/\/Schema\/WebhookRepositoryRulesetEdited\/Changes\/Rules.php",
-                "hash": "ede6ebd08fed824a61bb49bfd64b1db7"
+                "hash": "0fda80923f6a7152fcf303c561172347"
             },
             {
                 "name": ".\/clients\/GitHubEnterprise-3.15\/etc\/..\/\/src\/\/Internal\/Attribute\/CastUnionToType\/Schema\/WebhookRepositoryRulesetEdited\/Changes\/Rules\/Updated\/Rule.php",
@@ -24232,7 +24232,7 @@
             },
             {
                 "name": ".\/clients\/GitHubEnterprise-3.15\/etc\/..\/\/src\/\/Schema\/WebhookRepositoryRulesetEdited\/Changes\/Rules\/Updated.php",
-                "hash": "39f4b5c4a791351f38c8d1b2669810c3"
+                "hash": "149f282521e5208e5164cdce2f5a4751"
             },
             {
                 "name": ".\/clients\/GitHubEnterprise-3.15\/etc\/..\/\/src\/\/Schema\/WebhookRepositoryRulesetEdited\/Changes\/Rules\/Updated\/Changes.php",
@@ -25424,7 +25424,7 @@
             },
             {
                 "name": ".\/clients\/GitHubEnterprise-3.15\/etc\/..\/\/src\/\/Schema\/Repos\/CreateOrgRuleset\/Request\/ApplicationJson.php",
-                "hash": "72481fdf4c36853176806e6bfc6f80cf"
+                "hash": "97b4c0b8ebc50559cdd0f96cec759c0c"
             },
             {
                 "name": ".\/clients\/GitHubEnterprise-3.15\/etc\/..\/\/src\/\/Internal\/Attribute\/CastUnionToType\/Schema\/Repos\/UpdateOrgRuleset\/Request\/ApplicationJson\/Conditions.php",
@@ -25432,7 +25432,7 @@
             },
             {
                 "name": ".\/clients\/GitHubEnterprise-3.15\/etc\/..\/\/src\/\/Schema\/Repos\/UpdateOrgRuleset\/Request\/ApplicationJson.php",
-                "hash": "dc6e67d34d67e7cc6239d6b77c7ffdbb"
+                "hash": "eef98e81fe21a68e7aa18a4957ec5ad7"
             },
             {
                 "name": ".\/clients\/GitHubEnterprise-3.15\/etc\/..\/\/src\/\/Schema\/Teams\/Create\/Request\/ApplicationJson.php",
@@ -26464,11 +26464,11 @@
             },
             {
                 "name": ".\/clients\/GitHubEnterprise-3.15\/etc\/..\/\/src\/\/Schema\/Repos\/CreateRepoRuleset\/Request\/ApplicationJson.php",
-                "hash": "b18a65faad1c6f73891bb3db88c53cb7"
+                "hash": "a76fe3aeb2cbdae9d950fa62c33e118d"
             },
             {
                 "name": ".\/clients\/GitHubEnterprise-3.15\/etc\/..\/\/src\/\/Schema\/Repos\/UpdateRepoRuleset\/Request\/ApplicationJson.php",
-                "hash": "09d3787b01324c0c80d4d827c4ff62db"
+                "hash": "b6701b11fa847e3cb2ab5b650544d948"
             },
             {
                 "name": ".\/clients\/GitHubEnterprise-3.15\/etc\/..\/\/src\/\/Schema\/SecretScanning\/UpdateAlert\/Request\/ApplicationJson.php",

--- a/clients/GitHubEnterprise-3.15/src/Schema/Repos/CreateOrgRuleset/Request/ApplicationJson.php
+++ b/clients/GitHubEnterprise-3.15/src/Schema/Repos/CreateOrgRuleset/Request/ApplicationJson.php
@@ -566,6 +566,10 @@ final readonly class ApplicationJson
                                         },
                                         "description": "Array of allowed merge methods. Allowed values include `merge`, `squash`, and `rebase`. At least one option must be enabled."
                                     },
+                                    "automatic_copilot_code_review_enabled": {
+                                        "type": "boolean",
+                                        "description": "> [!NOTE]\\n> `automatic_copilot_code_review_enabled` is in beta and subject to change.\\n\\nAutomatically request review from Copilot for new pull requests, if the author has access to Copilot code review."
+                                    },
                                     "dismiss_stale_reviews_on_push": {
                                         "type": "boolean",
                                         "description": "New, reviewable commits pushed will dismiss previous pull request review approvals."

--- a/clients/GitHubEnterprise-3.15/src/Schema/Repos/CreateRepoRuleset/Request/ApplicationJson.php
+++ b/clients/GitHubEnterprise-3.15/src/Schema/Repos/CreateRepoRuleset/Request/ApplicationJson.php
@@ -347,6 +347,10 @@ final readonly class ApplicationJson
                                         },
                                         "description": "Array of allowed merge methods. Allowed values include `merge`, `squash`, and `rebase`. At least one option must be enabled."
                                     },
+                                    "automatic_copilot_code_review_enabled": {
+                                        "type": "boolean",
+                                        "description": "> [!NOTE]\\n> `automatic_copilot_code_review_enabled` is in beta and subject to change.\\n\\nAutomatically request review from Copilot for new pull requests, if the author has access to Copilot code review."
+                                    },
                                     "dismiss_stale_reviews_on_push": {
                                         "type": "boolean",
                                         "description": "New, reviewable commits pushed will dismiss previous pull request review approvals."

--- a/clients/GitHubEnterprise-3.15/src/Schema/Repos/UpdateOrgRuleset/Request/ApplicationJson.php
+++ b/clients/GitHubEnterprise-3.15/src/Schema/Repos/UpdateOrgRuleset/Request/ApplicationJson.php
@@ -561,6 +561,10 @@ final readonly class ApplicationJson
                                         },
                                         "description": "Array of allowed merge methods. Allowed values include `merge`, `squash`, and `rebase`. At least one option must be enabled."
                                     },
+                                    "automatic_copilot_code_review_enabled": {
+                                        "type": "boolean",
+                                        "description": "> [!NOTE]\\n> `automatic_copilot_code_review_enabled` is in beta and subject to change.\\n\\nAutomatically request review from Copilot for new pull requests, if the author has access to Copilot code review."
+                                    },
                                     "dismiss_stale_reviews_on_push": {
                                         "type": "boolean",
                                         "description": "New, reviewable commits pushed will dismiss previous pull request review approvals."

--- a/clients/GitHubEnterprise-3.15/src/Schema/Repos/UpdateRepoRuleset/Request/ApplicationJson.php
+++ b/clients/GitHubEnterprise-3.15/src/Schema/Repos/UpdateRepoRuleset/Request/ApplicationJson.php
@@ -342,6 +342,10 @@ final readonly class ApplicationJson
                                         },
                                         "description": "Array of allowed merge methods. Allowed values include `merge`, `squash`, and `rebase`. At least one option must be enabled."
                                     },
+                                    "automatic_copilot_code_review_enabled": {
+                                        "type": "boolean",
+                                        "description": "> [!NOTE]\\n> `automatic_copilot_code_review_enabled` is in beta and subject to change.\\n\\nAutomatically request review from Copilot for new pull requests, if the author has access to Copilot code review."
+                                    },
                                     "dismiss_stale_reviews_on_push": {
                                         "type": "boolean",
                                         "description": "New, reviewable commits pushed will dismiss previous pull request review approvals."

--- a/clients/GitHubEnterprise-3.15/src/Schema/RepositoryRule.php
+++ b/clients/GitHubEnterprise-3.15/src/Schema/RepositoryRule.php
@@ -245,6 +245,10 @@ final readonly class RepositoryRule
                             },
                             "description": "Array of allowed merge methods. Allowed values include `merge`, `squash`, and `rebase`. At least one option must be enabled."
                         },
+                        "automatic_copilot_code_review_enabled": {
+                            "type": "boolean",
+                            "description": "> [!NOTE]\\n> `automatic_copilot_code_review_enabled` is in beta and subject to change.\\n\\nAutomatically request review from Copilot for new pull requests, if the author has access to Copilot code review."
+                        },
                         "dismiss_stale_reviews_on_push": {
                             "type": "boolean",
                             "description": "New, reviewable commits pushed will dismiss previous pull request review approvals."

--- a/clients/GitHubEnterprise-3.15/src/Schema/RepositoryRuleDetailed.php
+++ b/clients/GitHubEnterprise-3.15/src/Schema/RepositoryRuleDetailed.php
@@ -429,6 +429,10 @@ final readonly class RepositoryRuleDetailed
                                     },
                                     "description": "Array of allowed merge methods. Allowed values include `merge`, `squash`, and `rebase`. At least one option must be enabled."
                                 },
+                                "automatic_copilot_code_review_enabled": {
+                                    "type": "boolean",
+                                    "description": "> [!NOTE]\\n> `automatic_copilot_code_review_enabled` is in beta and subject to change.\\n\\nAutomatically request review from Copilot for new pull requests, if the author has access to Copilot code review."
+                                },
                                 "dismiss_stale_reviews_on_push": {
                                     "type": "boolean",
                                     "description": "New, reviewable commits pushed will dismiss previous pull request review approvals."

--- a/clients/GitHubEnterprise-3.15/src/Schema/RepositoryRulePullRequest.php
+++ b/clients/GitHubEnterprise-3.15/src/Schema/RepositoryRulePullRequest.php
@@ -43,6 +43,10 @@ final readonly class RepositoryRulePullRequest
                     },
                     "description": "Array of allowed merge methods. Allowed values include `merge`, `squash`, and `rebase`. At least one option must be enabled."
                 },
+                "automatic_copilot_code_review_enabled": {
+                    "type": "boolean",
+                    "description": "> [!NOTE]\\n> `automatic_copilot_code_review_enabled` is in beta and subject to change.\\n\\nAutomatically request review from Copilot for new pull requests, if the author has access to Copilot code review."
+                },
                 "dismiss_stale_reviews_on_push": {
                     "type": "boolean",
                     "description": "New, reviewable commits pushed will dismiss previous pull request review approvals."
@@ -79,6 +83,7 @@ final readonly class RepositoryRulePullRequest
             "generated",
             "generated"
         ],
+        "automatic_copilot_code_review_enabled": false,
         "dismiss_stale_reviews_on_push": false,
         "require_code_owner_review": false,
         "require_last_push_approval": false,

--- a/clients/GitHubEnterprise-3.15/src/Schema/RepositoryRulePullRequest/Parameters.php
+++ b/clients/GitHubEnterprise-3.15/src/Schema/RepositoryRulePullRequest/Parameters.php
@@ -30,6 +30,10 @@ final readonly class Parameters
             },
             "description": "Array of allowed merge methods. Allowed values include `merge`, `squash`, and `rebase`. At least one option must be enabled."
         },
+        "automatic_copilot_code_review_enabled": {
+            "type": "boolean",
+            "description": "> [!NOTE]\\n> `automatic_copilot_code_review_enabled` is in beta and subject to change.\\n\\nAutomatically request review from Copilot for new pull requests, if the author has access to Copilot code review."
+        },
         "dismiss_stale_reviews_on_push": {
             "type": "boolean",
             "description": "New, reviewable commits pushed will dismiss previous pull request review approvals."
@@ -61,6 +65,7 @@ final readonly class Parameters
         "generated",
         "generated"
     ],
+    "automatic_copilot_code_review_enabled": false,
     "dismiss_stale_reviews_on_push": false,
     "require_code_owner_review": false,
     "require_last_push_approval": false,
@@ -70,6 +75,10 @@ final readonly class Parameters
 
     /**
      * allowedMergeMethods: Array of allowed merge methods. Allowed values include `merge`, `squash`, and `rebase`. At least one option must be enabled.
+     * automaticCopilotCodeReviewEnabled: > [!NOTE]
+    > `automatic_copilot_code_review_enabled` is in beta and subject to change.
+
+    Automatically request review from Copilot for new pull requests, if the author has access to Copilot code review.
      * dismissStaleReviewsOnPush: New, reviewable commits pushed will dismiss previous pull request review approvals.
      * requireCodeOwnerReview: Require an approving review in pull requests that modify files that have a designated code owner.
      * requireLastPushApproval: Whether the most recent reviewable push must be approved by someone other than the person who pushed it.
@@ -77,7 +86,8 @@ final readonly class Parameters
      * requiredReviewThreadResolution: All conversations on code must be resolved before a pull request can be merged.
      */
     public function __construct(#[MapFrom('allowed_merge_methods')]
-    public array|null $allowedMergeMethods, #[MapFrom('dismiss_stale_reviews_on_push')]
+    public array|null $allowedMergeMethods, #[MapFrom('automatic_copilot_code_review_enabled')]
+    public bool|null $automaticCopilotCodeReviewEnabled, #[MapFrom('dismiss_stale_reviews_on_push')]
     public bool $dismissStaleReviewsOnPush, #[MapFrom('require_code_owner_review')]
     public bool $requireCodeOwnerReview, #[MapFrom('require_last_push_approval')]
     public bool $requireLastPushApproval, #[MapFrom('required_approving_review_count')]

--- a/clients/GitHubEnterprise-3.15/src/Schema/RepositoryRuleset.php
+++ b/clients/GitHubEnterprise-3.15/src/Schema/RepositoryRuleset.php
@@ -656,6 +656,10 @@ final readonly class RepositoryRuleset
                                         },
                                         "description": "Array of allowed merge methods. Allowed values include `merge`, `squash`, and `rebase`. At least one option must be enabled."
                                     },
+                                    "automatic_copilot_code_review_enabled": {
+                                        "type": "boolean",
+                                        "description": "> [!NOTE]\\n> `automatic_copilot_code_review_enabled` is in beta and subject to change.\\n\\nAutomatically request review from Copilot for new pull requests, if the author has access to Copilot code review."
+                                    },
                                     "dismiss_stale_reviews_on_push": {
                                         "type": "boolean",
                                         "description": "New, reviewable commits pushed will dismiss previous pull request review approvals."

--- a/clients/GitHubEnterprise-3.15/src/Schema/WebhookRepositoryRulesetCreated.php
+++ b/clients/GitHubEnterprise-3.15/src/Schema/WebhookRepositoryRulesetCreated.php
@@ -2373,6 +2373,10 @@ final readonly class WebhookRepositoryRulesetCreated
                                                 },
                                                 "description": "Array of allowed merge methods. Allowed values include `merge`, `squash`, and `rebase`. At least one option must be enabled."
                                             },
+                                            "automatic_copilot_code_review_enabled": {
+                                                "type": "boolean",
+                                                "description": "> [!NOTE]\\n> `automatic_copilot_code_review_enabled` is in beta and subject to change.\\n\\nAutomatically request review from Copilot for new pull requests, if the author has access to Copilot code review."
+                                            },
                                             "dismiss_stale_reviews_on_push": {
                                                 "type": "boolean",
                                                 "description": "New, reviewable commits pushed will dismiss previous pull request review approvals."

--- a/clients/GitHubEnterprise-3.15/src/Schema/WebhookRepositoryRulesetDeleted.php
+++ b/clients/GitHubEnterprise-3.15/src/Schema/WebhookRepositoryRulesetDeleted.php
@@ -2373,6 +2373,10 @@ final readonly class WebhookRepositoryRulesetDeleted
                                                 },
                                                 "description": "Array of allowed merge methods. Allowed values include `merge`, `squash`, and `rebase`. At least one option must be enabled."
                                             },
+                                            "automatic_copilot_code_review_enabled": {
+                                                "type": "boolean",
+                                                "description": "> [!NOTE]\\n> `automatic_copilot_code_review_enabled` is in beta and subject to change.\\n\\nAutomatically request review from Copilot for new pull requests, if the author has access to Copilot code review."
+                                            },
                                             "dismiss_stale_reviews_on_push": {
                                                 "type": "boolean",
                                                 "description": "New, reviewable commits pushed will dismiss previous pull request review approvals."

--- a/clients/GitHubEnterprise-3.15/src/Schema/WebhookRepositoryRulesetEdited.php
+++ b/clients/GitHubEnterprise-3.15/src/Schema/WebhookRepositoryRulesetEdited.php
@@ -2373,6 +2373,10 @@ final readonly class WebhookRepositoryRulesetEdited
                                                 },
                                                 "description": "Array of allowed merge methods. Allowed values include `merge`, `squash`, and `rebase`. At least one option must be enabled."
                                             },
+                                            "automatic_copilot_code_review_enabled": {
+                                                "type": "boolean",
+                                                "description": "> [!NOTE]\\n> `automatic_copilot_code_review_enabled` is in beta and subject to change.\\n\\nAutomatically request review from Copilot for new pull requests, if the author has access to Copilot code review."
+                                            },
                                             "dismiss_stale_reviews_on_push": {
                                                 "type": "boolean",
                                                 "description": "New, reviewable commits pushed will dismiss previous pull request review approvals."
@@ -3248,6 +3252,10 @@ final readonly class WebhookRepositoryRulesetEdited
                                                         },
                                                         "description": "Array of allowed merge methods. Allowed values include `merge`, `squash`, and `rebase`. At least one option must be enabled."
                                                     },
+                                                    "automatic_copilot_code_review_enabled": {
+                                                        "type": "boolean",
+                                                        "description": "> [!NOTE]\\n> `automatic_copilot_code_review_enabled` is in beta and subject to change.\\n\\nAutomatically request review from Copilot for new pull requests, if the author has access to Copilot code review."
+                                                    },
                                                     "dismiss_stale_reviews_on_push": {
                                                         "type": "boolean",
                                                         "description": "New, reviewable commits pushed will dismiss previous pull request review approvals."
@@ -3949,6 +3957,10 @@ final readonly class WebhookRepositoryRulesetEdited
                                                             "type": "string"
                                                         },
                                                         "description": "Array of allowed merge methods. Allowed values include `merge`, `squash`, and `rebase`. At least one option must be enabled."
+                                                    },
+                                                    "automatic_copilot_code_review_enabled": {
+                                                        "type": "boolean",
+                                                        "description": "> [!NOTE]\\n> `automatic_copilot_code_review_enabled` is in beta and subject to change.\\n\\nAutomatically request review from Copilot for new pull requests, if the author has access to Copilot code review."
                                                     },
                                                     "dismiss_stale_reviews_on_push": {
                                                         "type": "boolean",
@@ -4654,6 +4666,10 @@ final readonly class WebhookRepositoryRulesetEdited
                                                                     "type": "string"
                                                                 },
                                                                 "description": "Array of allowed merge methods. Allowed values include `merge`, `squash`, and `rebase`. At least one option must be enabled."
+                                                            },
+                                                            "automatic_copilot_code_review_enabled": {
+                                                                "type": "boolean",
+                                                                "description": "> [!NOTE]\\n> `automatic_copilot_code_review_enabled` is in beta and subject to change.\\n\\nAutomatically request review from Copilot for new pull requests, if the author has access to Copilot code review."
                                                             },
                                                             "dismiss_stale_reviews_on_push": {
                                                                 "type": "boolean",

--- a/clients/GitHubEnterprise-3.15/src/Schema/WebhookRepositoryRulesetEdited/Changes.php
+++ b/clients/GitHubEnterprise-3.15/src/Schema/WebhookRepositoryRulesetEdited/Changes.php
@@ -411,6 +411,10 @@ final readonly class Changes
                                                 },
                                                 "description": "Array of allowed merge methods. Allowed values include `merge`, `squash`, and `rebase`. At least one option must be enabled."
                                             },
+                                            "automatic_copilot_code_review_enabled": {
+                                                "type": "boolean",
+                                                "description": "> [!NOTE]\\n> `automatic_copilot_code_review_enabled` is in beta and subject to change.\\n\\nAutomatically request review from Copilot for new pull requests, if the author has access to Copilot code review."
+                                            },
                                             "dismiss_stale_reviews_on_push": {
                                                 "type": "boolean",
                                                 "description": "New, reviewable commits pushed will dismiss previous pull request review approvals."
@@ -1112,6 +1116,10 @@ final readonly class Changes
                                                     "type": "string"
                                                 },
                                                 "description": "Array of allowed merge methods. Allowed values include `merge`, `squash`, and `rebase`. At least one option must be enabled."
+                                            },
+                                            "automatic_copilot_code_review_enabled": {
+                                                "type": "boolean",
+                                                "description": "> [!NOTE]\\n> `automatic_copilot_code_review_enabled` is in beta and subject to change.\\n\\nAutomatically request review from Copilot for new pull requests, if the author has access to Copilot code review."
                                             },
                                             "dismiss_stale_reviews_on_push": {
                                                 "type": "boolean",
@@ -1817,6 +1825,10 @@ final readonly class Changes
                                                             "type": "string"
                                                         },
                                                         "description": "Array of allowed merge methods. Allowed values include `merge`, `squash`, and `rebase`. At least one option must be enabled."
+                                                    },
+                                                    "automatic_copilot_code_review_enabled": {
+                                                        "type": "boolean",
+                                                        "description": "> [!NOTE]\\n> `automatic_copilot_code_review_enabled` is in beta and subject to change.\\n\\nAutomatically request review from Copilot for new pull requests, if the author has access to Copilot code review."
                                                     },
                                                     "dismiss_stale_reviews_on_push": {
                                                         "type": "boolean",

--- a/clients/GitHubEnterprise-3.15/src/Schema/WebhookRepositoryRulesetEdited/Changes/Rules.php
+++ b/clients/GitHubEnterprise-3.15/src/Schema/WebhookRepositoryRulesetEdited/Changes/Rules.php
@@ -250,6 +250,10 @@ final readonly class Rules
                                         },
                                         "description": "Array of allowed merge methods. Allowed values include `merge`, `squash`, and `rebase`. At least one option must be enabled."
                                     },
+                                    "automatic_copilot_code_review_enabled": {
+                                        "type": "boolean",
+                                        "description": "> [!NOTE]\\n> `automatic_copilot_code_review_enabled` is in beta and subject to change.\\n\\nAutomatically request review from Copilot for new pull requests, if the author has access to Copilot code review."
+                                    },
                                     "dismiss_stale_reviews_on_push": {
                                         "type": "boolean",
                                         "description": "New, reviewable commits pushed will dismiss previous pull request review approvals."
@@ -951,6 +955,10 @@ final readonly class Rules
                                             "type": "string"
                                         },
                                         "description": "Array of allowed merge methods. Allowed values include `merge`, `squash`, and `rebase`. At least one option must be enabled."
+                                    },
+                                    "automatic_copilot_code_review_enabled": {
+                                        "type": "boolean",
+                                        "description": "> [!NOTE]\\n> `automatic_copilot_code_review_enabled` is in beta and subject to change.\\n\\nAutomatically request review from Copilot for new pull requests, if the author has access to Copilot code review."
                                     },
                                     "dismiss_stale_reviews_on_push": {
                                         "type": "boolean",
@@ -1656,6 +1664,10 @@ final readonly class Rules
                                                     "type": "string"
                                                 },
                                                 "description": "Array of allowed merge methods. Allowed values include `merge`, `squash`, and `rebase`. At least one option must be enabled."
+                                            },
+                                            "automatic_copilot_code_review_enabled": {
+                                                "type": "boolean",
+                                                "description": "> [!NOTE]\\n> `automatic_copilot_code_review_enabled` is in beta and subject to change.\\n\\nAutomatically request review from Copilot for new pull requests, if the author has access to Copilot code review."
                                             },
                                             "dismiss_stale_reviews_on_push": {
                                                 "type": "boolean",

--- a/clients/GitHubEnterprise-3.15/src/Schema/WebhookRepositoryRulesetEdited/Changes/Rules/Updated.php
+++ b/clients/GitHubEnterprise-3.15/src/Schema/WebhookRepositoryRulesetEdited/Changes/Rules/Updated.php
@@ -251,6 +251,10 @@ final readonly class Updated
                                     },
                                     "description": "Array of allowed merge methods. Allowed values include `merge`, `squash`, and `rebase`. At least one option must be enabled."
                                 },
+                                "automatic_copilot_code_review_enabled": {
+                                    "type": "boolean",
+                                    "description": "> [!NOTE]\\n> `automatic_copilot_code_review_enabled` is in beta and subject to change.\\n\\nAutomatically request review from Copilot for new pull requests, if the author has access to Copilot code review."
+                                },
                                 "dismiss_stale_reviews_on_push": {
                                     "type": "boolean",
                                     "description": "New, reviewable commits pushed will dismiss previous pull request review approvals."


### PR DESCRIPTION
Detected Schema changes:



```
└─┬Components
  └─┬repository-rule-pull-request
    └─┬parameters
      └──[➖] properties (77585:13)❌ 

```

| Document Element | Total Changes | Breaking Changes |
|------------------|---------------|------------------|
| components       | 1             | 1                |

Date: 03/25/25 | Commit: Original: etc/specs/GitHubEnterprise-3.15/current.spec.yaml, Modified: etc/specs/GitHubEnterprise-3.15/previous.spec.yaml, 

- ❌ **BREAKING Changes**: _1_ out of _1_
- **Removals**: _1_
- **Breaking Removals**: _1_

ERROR: breaking changes discovered
