### PR TITLE
[GitHubEnterprise-3.13] Update to 1.1.4-9132531bf7c2236209780366a1c898ae from 1.1.4-b39b954044a7394ab4e5fe3ce2b56edc

### DIFF
--- a/clients/GitHubEnterprise-3.13/etc/openapi-client-generator.state
+++ b/clients/GitHubEnterprise-3.13/etc/openapi-client-generator.state
@@ -1,5 +1,5 @@
 {
-    "specHash": "b39b954044a7394ab4e5fe3ce2b56edc",
+    "specHash": "9132531bf7c2236209780366a1c898ae",
     "generatedFiles": {
         "files": [
             {


### PR DESCRIPTION
Detected Schema changes:



```
└─┬Paths
  └─┬/repos/{owner}/{repo}/commits/{commit_sha}/pulls
    └─┬GET
      └──[🔀] description (26786:20)

```

| Document Element | Total Changes | Breaking Changes |
|------------------|---------------|------------------|
| paths            | 1             | 0                |

Date: 03/27/25 | Commit: Original: etc/specs/GitHubEnterprise-3.13/current.spec.yaml, Modified: etc/specs/GitHubEnterprise-3.13/previous.spec.yaml, 

- **Total Changes**: _1_
- **Modifications**: _1_
